### PR TITLE
fix(agents): 修复 HIL 工具审批 interrupt 被误当 ask_user_question 处理

### DIFF
--- a/backend/package/yuxi/services/agent_run_service.py
+++ b/backend/package/yuxi/services/agent_run_service.py
@@ -146,6 +146,8 @@ def _compact_stream_chunk(chunk: dict) -> dict:
             "interrupt_info",
             "source",
             "agent_state",
+            "action_requests",
+            "review_configs",
         )
         if chunk.get(key) is not None and chunk.get(key) != ""
     }

--- a/backend/package/yuxi/services/chat_service.py
+++ b/backend/package/yuxi/services/chat_service.py
@@ -593,6 +593,45 @@ def _build_ask_user_question_payload(info: Any, thread_id: str) -> dict[str, Any
     }
 
 
+def _is_human_approval_payload(payload: dict) -> bool:
+    """判断 interrupt 是否为 HumanInTheLoopMiddleware 的工具审批载荷。
+
+    HIL 中间件产生的 interrupt value 含 ``action_requests``(待审批的工具调用)
+    与 ``review_configs``(每个工具允许的决策类型),与 ask_user_question 的
+    ``questions`` 结构不同。用 ``action_requests`` 作为判别依据。
+    """
+    action_requests = payload.get("action_requests")
+    return isinstance(action_requests, list) and len(action_requests) > 0
+
+
+def _build_human_approval_payload(info: Any, thread_id: str) -> dict[str, Any]:
+    """将 HIL 工具审批 interrupt 标准化为 human_approval_required 载荷。"""
+    payload = _coerce_interrupt_payload(info)
+
+    action_requests = payload.get("action_requests") or []
+    review_configs = payload.get("review_configs") or []
+
+    # 为每个 action_request 补齐 description(供前端展示),保留原始字段
+    normalized_actions: list[dict[str, Any]] = []
+    for action in action_requests:
+        if not isinstance(action, dict):
+            continue
+        action = dict(action)
+        if not action.get("description"):
+            action["description"] = "操作需要确认\n\nTool: {name}\nArgs: {args}".format(
+                name=action.get("name", ""),
+                args=action.get("args", {}),
+            )
+        normalized_actions.append(action)
+
+    return {
+        "action_requests": normalized_actions,
+        "review_configs": review_configs,
+        "source": "human_approval",
+        "thread_id": thread_id,
+    }
+
+
 def _ensure_full_msg(full_msg: AIMessage | None, accumulated_content: list[str]) -> AIMessage | None:
     """如果 full_msg 为空且有累积内容，构建 AIMessage"""
     if not full_msg and accumulated_content:
@@ -673,9 +712,15 @@ async def check_and_handle_interrupts(
 
         interrupt_info = _extract_interrupt_info(state)
         if interrupt_info:
-            question_payload = _build_ask_user_question_payload(interrupt_info, thread_id)
-            meta["interrupt"] = question_payload
-            yield make_chunk(status="ask_user_question_required", meta=meta, **question_payload)
+            payload = _coerce_interrupt_payload(interrupt_info)
+            if _is_human_approval_payload(payload):
+                approval_payload = _build_human_approval_payload(interrupt_info, thread_id)
+                meta["interrupt"] = approval_payload
+                yield make_chunk(status="human_approval_required", meta=meta, **approval_payload)
+            else:
+                question_payload = _build_ask_user_question_payload(interrupt_info, thread_id)
+                meta["interrupt"] = question_payload
+                yield make_chunk(status="ask_user_question_required", meta=meta, **question_payload)
 
     except Exception as e:
         logger.exception(f"Error checking interrupts: {e}")

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -229,6 +229,35 @@ def _chunk_thread_id(chunk: dict, fallback: str | None) -> str | None:
     return _thread_id_from_mapping(chunk) or fallback
 
 
+def _interrupt_summary(chunk: dict) -> str:
+    """从 interrupt chunk 提取人类可读的摘要。
+
+    兼容两类 interrupt 载荷:ask_user_question 的 ``questions`` 与
+    HumanInTheLoop 的 ``action_requests``(工具审批)。无可用信息时返回空串。
+    """
+    if not isinstance(chunk, dict):
+        return ""
+
+    questions = chunk.get("questions")
+    if isinstance(questions, list) and questions:
+        first = questions[0]
+        if isinstance(first, dict):
+            return str(first.get("question") or "").strip()
+
+    action_requests = chunk.get("action_requests")
+    if isinstance(action_requests, list) and action_requests:
+        first = action_requests[0]
+        if isinstance(first, dict):
+            name = str(first.get("name") or "").strip()
+            args = first.get("args")
+            if name:
+                if args:
+                    return f"操作需要确认: {name}({args})"
+                return f"操作需要确认: {name}"
+
+    return ""
+
+
 def _map_chunk_to_run_event(chunk: dict) -> tuple[str, dict]:
     status = chunk.get("status") or "event"
     if status == "loading":
@@ -407,12 +436,7 @@ async def process_agent_run(ctx, run_id: str):
                         await _append_end_event(run_id, status_value, thread_id=thread_id, payload={"chunk": chunk})
                         terminal_set = True
                     elif status in {"ask_user_question_required", "human_approval_required"}:
-                        questions = chunk.get("questions") if isinstance(chunk, dict) else None
-                        first_question = ""
-                        if isinstance(questions, list) and questions:
-                            first = questions[0]
-                            if isinstance(first, dict):
-                                first_question = str(first.get("question") or "").strip()
+                        first_question = _interrupt_summary(chunk)
 
                         await mark_run_terminal(
                             run_id,

--- a/backend/test/unit/services/test_agent_run_service.py
+++ b/backend/test/unit/services/test_agent_run_service.py
@@ -1145,3 +1145,46 @@ async def test_create_resume_run_inherits_parent_model_spec(monkeypatch: pytest.
     )
 
     assert captured["input_payload"]["model_spec"] == "parent-model"
+
+
+class TestCompactStreamChunkHil:
+    """测试 _compact_stream_chunk 在 verbose=false 精简时保留 HIL 工具审批字段。
+
+    回归:修复前白名单漏掉 action_requests/review_configs,前端收到空弹窗。
+    """
+
+    def test_compact_keeps_human_approval_action_requests(self):
+        chunk = {
+            "status": "human_approval_required",
+            "action_requests": [{"name": "delete_file", "args": {"path": "/x"}}],
+            "review_configs": [{"action_name": "delete_file", "allowed_decisions": ["approve", "reject"]}],
+            "source": "human_approval",
+        }
+        compact = agent_run_service._compact_stream_chunk(chunk)
+
+        assert compact["status"] == "human_approval_required"
+        assert compact["action_requests"] == chunk["action_requests"]
+        assert compact["review_configs"] == chunk["review_configs"]
+
+    def test_compact_keeps_ask_user_question_questions(self):
+        """ask_user_question 的 questions 仍保留(未回归)。"""
+        chunk = {
+            "status": "ask_user_question_required",
+            "questions": [{"question": "选择一个", "options": ["A"]}],
+        }
+        compact = agent_run_service._compact_stream_chunk(chunk)
+
+        assert compact["questions"] == chunk["questions"]
+
+    def test_compact_drops_missing_fields(self):
+        """白名单外的字段被丢弃;白名单内但未提供的字段不出现。"""
+        chunk = {
+            "status": "human_approval_required",
+            "extra_field": "should be dropped",
+        }
+        compact = agent_run_service._compact_stream_chunk(chunk)
+
+        assert compact["status"] == "human_approval_required"
+        assert "extra_field" not in compact
+        assert "action_requests" not in compact
+        assert "review_configs" not in compact

--- a/backend/test/unit/services/test_chat_stream_interrupt.py
+++ b/backend/test/unit/services/test_chat_stream_interrupt.py
@@ -12,10 +12,14 @@ sys.path.insert(0, os.getcwd())
 from yuxi.services.chat_service import (
     _normalize_interrupt_questions,
     _build_ask_user_question_payload,
+    _build_human_approval_payload,
+    _is_human_approval_payload,
     _coerce_interrupt_payload,
+    check_and_handle_interrupts,
     stream_agent_resume,
 )
 from yuxi.services import chat_service as svc
+from yuxi.services import run_worker
 from yuxi.utils.question_utils import normalize_options
 
 
@@ -215,9 +219,12 @@ async def test_stream_agent_resume_routes_subagent_chunks(monkeypatch):
         context_schema = FakeContext
 
         async def stream_resume_with_state(self, resume_command, input_context=None, **kwargs):
-            yield "messages", (
-                {"content": "child token", "id": "msg-child"},
-                {"namespace": ["task:1"], "thread_id": "child-thread"},
+            yield (
+                "messages",
+                (
+                    {"content": "child token", "id": "msg-child"},
+                    {"namespace": ["task:1"], "thread_id": "child-thread"},
+                ),
             )
 
         async def get_graph(self, context=None):
@@ -290,3 +297,132 @@ class TestCoerceInterruptPayload:
     def test_none_input(self):
         result = _coerce_interrupt_payload(None)
         assert isinstance(result, dict)
+
+
+class TestHumanApprovalPayloadDetection:
+    """测试 HIL 工具审批 interrupt 的判别与载荷构建。"""
+
+    def test_is_human_approval_payload_true_for_action_requests(self):
+        payload = {"action_requests": [{"name": "delete_file", "args": {"path": "/x"}}], "review_configs": []}
+        assert _is_human_approval_payload(payload) is True
+
+    def test_is_human_approval_payload_false_for_questions(self):
+        assert _is_human_approval_payload({"questions": [{"question": "Q"}]}) is False
+
+    def test_is_human_approval_payload_false_for_empty(self):
+        assert _is_human_approval_payload({}) is False
+        assert _is_human_approval_payload({"action_requests": []}) is False
+
+    def test_build_human_approval_payload_preserves_action_requests(self):
+        info = {
+            "action_requests": [{"name": "send_email", "args": {"to": "a@b.com"}, "description": "需要确认"}],
+            "review_configs": [{"action_name": "send_email", "allowed_decisions": ["approve", "reject"]}],
+        }
+        result = _build_human_approval_payload(info, "thread-hil-1")
+
+        assert result["source"] == "human_approval"
+        assert result["thread_id"] == "thread-hil-1"
+        assert len(result["action_requests"]) == 1
+        assert result["action_requests"][0]["name"] == "send_email"
+        assert result["action_requests"][0]["description"] == "需要确认"
+        assert result["review_configs"][0]["allowed_decisions"] == ["approve", "reject"]
+
+    def test_build_human_approval_payload_fills_missing_description(self):
+        """HIL payload 缺 description 时补默认提示,便于前端展示。"""
+        info = {"action_requests": [{"name": "delete_file", "args": {"path": "/tmp/x"}}], "review_configs": []}
+        result = _build_human_approval_payload(info, "thread-hil-2")
+
+        desc = result["action_requests"][0]["description"]
+        assert "delete_file" in desc
+        assert "/tmp/x" in desc
+
+
+class TestCheckAndHandleInterruptsRouting:
+    """测试 check_and_handle_interrupts 按载荷类型分流到 ask_user_question / human_approval。"""
+
+    @pytest.mark.asyncio
+    async def test_routes_human_approval_interrupt_to_human_approval_required(self):
+        """HIL interrupt(含 action_requests)应发 human_approval_required,不再塞默认空问题。"""
+        hil_value = {
+            "action_requests": [{"name": "delete_file", "args": {"path": "/x"}}],
+            "review_configs": [{"action_name": "delete_file", "allowed_decisions": ["approve", "reject"]}],
+        }
+
+        class FakeGraph:
+            async def aget_state(self, _config):
+                return SimpleNamespace(
+                    values={"__interrupt__": [SimpleNamespace(value=hil_value)]},
+                    tasks=[],
+                )
+
+        class FakeAgent:
+            async def get_graph(self):
+                return FakeGraph()
+
+        chunks: list[dict] = []
+
+        def make_chunk(status, meta, **kwargs):
+            return json.dumps({"status": status, "meta": meta, **kwargs}, ensure_ascii=False).encode("utf-8")
+
+        stream = check_and_handle_interrupts(FakeAgent(), {"configurable": {"thread_id": "t"}}, make_chunk, {}, "t")
+        async for raw in stream:
+            chunks.append(json.loads(raw.decode("utf-8")))
+
+        assert len(chunks) == 1
+        assert chunks[0]["status"] == "human_approval_required"
+        assert "action_requests" in chunks[0]
+        assert chunks[0]["action_requests"][0]["name"] == "delete_file"
+        assert "review_configs" in chunks[0]
+        # 不应再出现被误塞的默认空问题
+        assert "questions" not in chunks[0]
+
+    @pytest.mark.asyncio
+    async def test_routes_ask_user_question_interrupt_unchanged(self):
+        """ask_user_question interrupt(含 questions)仍走原有 ask_user_question_required 通道。"""
+        info_value = {"questions": [{"question": "选择一个", "options": ["A", "B"]}]}
+
+        class FakeGraph:
+            async def aget_state(self, _config):
+                return SimpleNamespace(
+                    values={"__interrupt__": [SimpleNamespace(value=info_value)]},
+                    tasks=[],
+                )
+
+        class FakeAgent:
+            async def get_graph(self):
+                return FakeGraph()
+
+        chunks: list[dict] = []
+
+        def make_chunk(status, meta, **kwargs):
+            return json.dumps({"status": status, "meta": meta, **kwargs}, ensure_ascii=False).encode("utf-8")
+
+        stream = check_and_handle_interrupts(FakeAgent(), {"configurable": {"thread_id": "t"}}, make_chunk, {}, "t")
+        async for raw in stream:
+            chunks.append(json.loads(raw.decode("utf-8")))
+
+        assert len(chunks) == 1
+        assert chunks[0]["status"] == "ask_user_question_required"
+        assert chunks[0]["questions"][0]["question"] == "选择一个"
+
+
+class TestInterruptSummary:
+    """测试 run_worker._interrupt_summary 兼容两类 interrupt 载荷。"""
+
+    def test_summary_from_questions(self):
+        chunk = {"questions": [{"question": "是否继续？"}]}
+        assert run_worker._interrupt_summary(chunk) == "是否继续？"
+
+    def test_summary_from_action_requests_with_args(self):
+        chunk = {"action_requests": [{"name": "delete_file", "args": {"path": "/x"}}]}
+        summary = run_worker._interrupt_summary(chunk)
+        assert "delete_file" in summary
+        assert "/x" in summary
+
+    def test_summary_from_action_requests_without_args(self):
+        chunk = {"action_requests": [{"name": "send_email", "args": {}}]}
+        assert run_worker._interrupt_summary(chunk) == "操作需要确认: send_email"
+
+    def test_summary_empty_when_no_payload(self):
+        assert run_worker._interrupt_summary({}) == ""
+        assert run_worker._interrupt_summary(None) == ""

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -125,10 +125,20 @@
           <div class="bottom" :class="{ 'start-screen': !conversations.length }">
             <!-- 人工审批弹窗 - 放在输入框上方 -->
             <HumanApprovalModal
+              v-if="isAskUserApproval"
               :visible="currentApprovalModalVisible"
               :questions="currentApprovalQuestions"
               @submit="handleQuestionSubmit"
               @cancel="handleQuestionCancel"
+            />
+            <HumanToolApprovalModal
+              v-else
+              :visible="currentApprovalModalVisible"
+              :action-requests="currentApprovalActionRequests"
+              :review-configs="currentApprovalReviewConfigs"
+              @approve="handleToolApprovalSubmit"
+              @reject="handleToolApprovalReject"
+              @edit="handleToolApprovalSubmit"
             />
 
             <div class="message-input-wrapper">
@@ -596,6 +606,7 @@ import { storeToRefs } from 'pinia'
 import { MessageProcessor } from '@/utils/messageProcessor'
 import { agentApi, threadApi } from '@/apis'
 import HumanApprovalModal from '@/components/HumanApprovalModal.vue'
+import HumanToolApprovalModal from '@/components/HumanToolApprovalModal.vue'
 import { useApproval } from '@/composables/useApproval'
 import { useAgentThreadState } from '@/composables/useAgentThreadState'
 import { useAgentRunStream } from '@/composables/useAgentRunStream'
@@ -1307,8 +1318,23 @@ const currentApprovalModalVisible = computed(
     Boolean(approvalState.threadId) &&
     approvalState.threadId === currentChatId.value
 )
+const isAskUserApproval = computed(
+  () => approvalState.kind !== 'human_approval'
+)
 const currentApprovalQuestions = computed(() =>
-  currentApprovalModalVisible.value ? approvalState.questions : []
+  currentApprovalModalVisible.value && isAskUserApproval.value
+    ? approvalState.questions
+    : []
+)
+const currentApprovalActionRequests = computed(() =>
+  currentApprovalModalVisible.value && !isAskUserApproval.value
+    ? approvalState.actionRequests
+    : []
+)
+const currentApprovalReviewConfigs = computed(() =>
+  currentApprovalModalVisible.value && !isAskUserApproval.value
+    ? approvalState.reviewConfigs
+    : []
 )
 
 const shouldSuppressRefsForApproval = () =>
@@ -2486,6 +2512,15 @@ const handleQuestionSubmit = (answer) => {
 
 const handleQuestionCancel = () => {
   handleApprovalWithStream('reject')
+}
+
+// HIL 工具审批：approve/edit/reject 均发送 { decisions: [...] }
+const handleToolApprovalSubmit = (payload) => {
+  handleApprovalWithStream(payload)
+}
+
+const handleToolApprovalReject = (payload) => {
+  handleApprovalWithStream(payload)
 }
 
 const buildExportPayload = () => {

--- a/web/src/components/HumanToolApprovalModal.vue
+++ b/web/src/components/HumanToolApprovalModal.vue
@@ -1,0 +1,406 @@
+<template>
+  <transition name="slide-up">
+    <div v-if="visible && actionRequests.length" class="approval-modal">
+      <div class="approval-content">
+        <div class="approval-header">
+          <h4>操作需要确认</h4>
+          <span v-if="actionRequests.length > 1" class="action-count">
+            共 {{ actionRequests.length }} 个操作
+          </span>
+        </div>
+
+        <div
+          v-for="(action, index) in actionRequests"
+          :key="index"
+          class="action-block"
+        >
+          <div class="action-meta">
+            <span class="action-label">工具：</span>
+            <code class="action-name">{{ action.name }}</code>
+          </div>
+          <div class="action-meta">
+            <span class="action-label">参数：</span>
+            <code class="action-args">{{ formatArgs(action.args) }}</code>
+          </div>
+          <p v-if="action.description" class="action-desc">{{ action.description }}</p>
+
+          <div v-if="editingIndex === index" class="edit-area">
+            <textarea
+              v-model="editText"
+              class="edit-textarea"
+              :disabled="isProcessing"
+              spellcheck="false"
+            />
+            <p v-if="editError" class="edit-error">{{ editError }}</p>
+          </div>
+        </div>
+
+        <div v-if="actionRequests.length > 1" class="hint">
+          所有操作将使用同一决策，编辑模式会把参数应用到每个操作。
+        </div>
+      </div>
+
+      <div class="approval-actions">
+        <button class="btn btn-reject" :disabled="isProcessing" @click="handleReject">拒绝</button>
+        <button
+          v-if="canEdit"
+          class="btn btn-edit"
+          :disabled="isProcessing"
+          @click="toggleEdit"
+        >
+          {{ editingIndex === null ? '编辑参数' : '取消编辑' }}
+        </button>
+        <button class="btn btn-approve" :disabled="isProcessing" @click="handlePrimary">
+          确认执行
+        </button>
+      </div>
+
+      <div v-if="isProcessing" class="approval-processing">
+        <span class="processing-spinner"></span>
+        处理中...
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+
+const props = defineProps({
+  visible: { type: Boolean, default: false },
+  actionRequests: { type: Array, default: () => [] },
+  reviewConfigs: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['approve', 'reject', 'edit'])
+
+const isProcessing = ref(false)
+const editingIndex = ref(null)
+const editText = ref('')
+const editError = ref('')
+
+const canEdit = computed(() => {
+  if (props.actionRequests.length !== 1) return false
+  const cfg = props.reviewConfigs[0]
+  if (!cfg) return true
+  const allowed = cfg.allowed_decisions || cfg.allowedDecisions || []
+  return allowed.length === 0 || allowed.includes('edit')
+})
+
+const formatArgs = (args) => {
+  if (args === null || args === undefined) return ''
+  if (typeof args === 'string') return args
+  try {
+    return JSON.stringify(args, null, 2)
+  } catch {
+    return String(args)
+  }
+}
+
+const toggleEdit = () => {
+  if (editingIndex.value === null) {
+    const action = props.actionRequests[0]
+    editText.value = formatArgs(action?.args)
+    editError.value = ''
+    editingIndex.value = 0
+  } else {
+    editingIndex.value = null
+    editText.value = ''
+    editError.value = ''
+  }
+}
+
+const parseEditedArgs = () => {
+  try {
+    const parsed = JSON.parse(editText.value)
+    editError.value = ''
+    return parsed
+  } catch (e) {
+    editError.value = `参数不是合法 JSON：${e.message}`
+    return null
+  }
+}
+
+const buildDecisions = (type, extra = {}) => {
+  // 每个待审批操作生成一个决策，顺序与 actionRequests 一致
+  return props.actionRequests.map((action) => {
+    if (type === 'edit') {
+      return {
+        type: 'edit',
+        edited_action: {
+          name: action.name,
+          args: extra.args
+        }
+      }
+    }
+    return { type }
+  })
+}
+
+const handleApprove = () => {
+  if (isProcessing.value) return
+  isProcessing.value = true
+  emit('approve', { decisions: buildDecisions('approve') })
+}
+
+const handleReject = () => {
+  if (isProcessing.value) return
+  isProcessing.value = true
+  emit('reject', { decisions: buildDecisions('reject') })
+}
+
+const handleEdit = () => {
+  if (isProcessing.value) return
+  const parsed = parseEditedArgs()
+  if (parsed === null) return
+  isProcessing.value = true
+  emit('edit', { decisions: buildDecisions('edit', { args: parsed }) })
+}
+
+// 确认执行：若正在编辑参数则走 edit，否则走 approve
+const handlePrimary = () => {
+  if (editingIndex.value !== null) {
+    handleEdit()
+  } else {
+    handleApprove()
+  }
+}
+
+defineExpose({ handlePrimary })
+
+watch(
+  () => props.visible,
+  (val) => {
+    if (!val) {
+      isProcessing.value = false
+      editingIndex.value = null
+      editText.value = ''
+      editError.value = ''
+    }
+  }
+)
+</script>
+
+<style scoped>
+.approval-modal {
+  background: var(--gray-0);
+  border-radius: 12px;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.12);
+  margin: 0 auto 8px;
+  max-width: 800px;
+  min-width: 360px;
+  width: fit-content;
+  border: 1px solid var(--gray-200);
+}
+
+.approval-content {
+  padding: 16px 20px;
+}
+
+.approval-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.approval-header h4 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.action-count {
+  font-size: 12px;
+  color: var(--gray-600);
+}
+
+.action-block {
+  background: var(--gray-50);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 10px;
+}
+
+.action-block:last-of-type {
+  margin-bottom: 0;
+}
+
+.action-meta {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 13px;
+  line-height: 1.6;
+  margin-bottom: 4px;
+}
+
+.action-label {
+  color: var(--gray-600);
+  flex-shrink: 0;
+}
+
+.action-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--main-700);
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.action-args {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--gray-800);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.action-desc {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--gray-600);
+  white-space: pre-wrap;
+}
+
+.edit-area {
+  margin-top: 8px;
+}
+
+.edit-textarea {
+  width: 100%;
+  min-height: 96px;
+  border: 1px solid var(--gray-200);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.edit-textarea:focus {
+  border-color: var(--main-color);
+}
+
+.edit-error {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #d93025;
+}
+
+.hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--gray-600);
+}
+
+.approval-actions {
+  display: flex;
+  gap: 10px;
+  padding: 12px 20px 16px;
+}
+
+.btn {
+  flex: 1;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-reject {
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+
+.btn-reject:hover:not(:disabled) {
+  background: var(--gray-200);
+}
+
+.btn-edit {
+  background: var(--gray-50);
+  color: var(--gray-700);
+  border: 1px solid var(--gray-200);
+}
+
+.btn-edit:hover:not(:disabled) {
+  background: var(--gray-100);
+}
+
+.btn-approve {
+  background: var(--main-color);
+  color: var(--gray-0);
+}
+
+.btn-approve:hover:not(:disabled) {
+  background: var(--main-700);
+}
+
+.approval-processing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px;
+  color: var(--gray-600);
+  font-size: 13px;
+  background: var(--gray-50);
+  border-top: 1px solid var(--gray-100);
+  border-radius: 0 0 12px 12px;
+}
+
+.processing-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--gray-200);
+  border-top-color: var(--main-color);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: all 0.25s ease;
+}
+
+.slide-up-enter-from {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+@media (max-width: 520px) {
+  .approval-modal {
+    width: calc(100vw - 12px);
+    min-width: 0;
+  }
+
+  .approval-content {
+    padding: 12px 16px;
+  }
+
+  .btn {
+    padding: 8px 16px;
+    font-size: 13px;
+  }
+}
+</style>

--- a/web/src/composables/__tests__/useApproval.test.js
+++ b/web/src/composables/__tests__/useApproval.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+
+import { extractPendingInterrupt } from '../approvalInterrupt.js'
+
+const run = () => {
+  // ask_user_question: 仍走 questions 通道
+  const askChunk = {
+    status: 'ask_user_question_required',
+    questions: [{ question: '选择一个', options: ['A', 'B'] }],
+    source: 'ask_user',
+    thread_id: 't1',
+    run_id: 'run-1'
+  }
+  const askPending = extractPendingInterrupt(askChunk, 't1')
+  assert.equal(askPending.kind, 'ask_user_question')
+  assert.equal(askPending.questions.length, 1)
+  assert.equal(askPending.parentRunId, 'run-1')
+
+  // human_approval: 走 action_requests 通道
+  const hilChunk = {
+    status: 'human_approval_required',
+    action_requests: [{ name: 'delete_file', args: { path: '/tmp/x' }, description: '需要确认' }],
+    review_configs: [{ action_name: 'delete_file', allowed_decisions: ['approve', 'reject'] }],
+    thread_id: 't2',
+    run_id: 'run-2'
+  }
+  const hilPending = extractPendingInterrupt(hilChunk, 't2')
+  assert.equal(hilPending.kind, 'human_approval')
+  assert.equal(hilPending.actionRequests.length, 1)
+  assert.equal(hilPending.actionRequests[0].name, 'delete_file')
+  assert.equal(hilPending.reviewConfigs.length, 1)
+  assert.equal(hilPending.parentRunId, 'run-2')
+  assert.equal(hilPending.questions, undefined)
+
+  // human_approval 但 payload 被误塞空 questions(修复前的退化情形)→ 应返回 null
+  const degradedChunk = {
+    status: 'human_approval_required',
+    questions: []
+  }
+  assert.equal(extractPendingInterrupt(degradedChunk, 't3'), null)
+
+  // 非 interrupt 状态 → null
+  assert.equal(extractPendingInterrupt({ status: 'finished' }, 't4'), null)
+}
+
+run()

--- a/web/src/composables/approvalInterrupt.js
+++ b/web/src/composables/approvalInterrupt.js
@@ -1,0 +1,52 @@
+import { normalizeQuestions } from '../utils/questionUtils.js'
+
+const APPROVAL_REQUIRED_STATUSES = new Set([
+  'ask_user_question_required',
+  'human_approval_required'
+])
+
+/**
+ * 从流式 chunk 提取待处理的 interrupt。
+ *
+ * 两类 interrupt:
+ * - ask_user_question: 走 questions 通道(选项式问询)
+ * - human_approval: 走 action_requests 通道(HumanInTheLoopMiddleware 工具审批)
+ *
+ * 返回 null 表示该 chunk 不是可处理的 interrupt(或 payload 缺关键字段)。
+ */
+export const extractPendingInterrupt = (chunk, threadId) => {
+  const status = chunk?.status || ''
+  if (!APPROVAL_REQUIRED_STATUSES.has(status)) return null
+
+  const fallbackThreadId = chunk?.thread_id || threadId
+  const parentRunId = chunk?.run_id || chunk?.parent_run_id || null
+  const interruptInfo = chunk?.interrupt_info || {}
+
+  if (status === 'human_approval_required') {
+    const actionRequests = chunk?.action_requests || interruptInfo?.action_requests || []
+    const reviewConfigs = chunk?.review_configs || interruptInfo?.review_configs || []
+    const list = Array.isArray(actionRequests) ? actionRequests : []
+    if (!list.length) return null
+    return {
+      kind: 'human_approval',
+      actionRequests: list,
+      reviewConfigs: Array.isArray(reviewConfigs) ? reviewConfigs : [],
+      status,
+      threadId: fallbackThreadId,
+      parentRunId
+    }
+  }
+
+  const rawQuestions = chunk?.questions || interruptInfo?.questions || []
+  const questions = normalizeQuestions(rawQuestions)
+  if (!questions.length) return null
+
+  return {
+    kind: 'ask_user_question',
+    questions,
+    source: chunk?.source || interruptInfo?.source || 'interrupt',
+    status,
+    threadId: fallbackThreadId,
+    parentRunId
+  }
+}

--- a/web/src/composables/useAgentRunStream.js
+++ b/web/src/composables/useAgentRunStream.js
@@ -153,7 +153,10 @@ export function useAgentRunStream({
 
   const hasPendingInterruptForRun = (threadState, runId) => {
     const pendingInterrupt = threadState?.pendingInterrupt
-    if (!pendingInterrupt?.questions?.length) return false
+    // 兼容两类 interrupt:ask_user_question(questions)与 human_approval(actionRequests)
+    const hasPayload =
+      pendingInterrupt?.questions?.length > 0 || pendingInterrupt?.actionRequests?.length > 0
+    if (!hasPayload) return false
     return !pendingInterrupt.parentRunId || pendingInterrupt.parentRunId === runId
   }
 

--- a/web/src/composables/useApproval.js
+++ b/web/src/composables/useApproval.js
@@ -1,40 +1,15 @@
 import { reactive } from 'vue'
-import { normalizeQuestions } from '@/utils/questionUtils'
+import { extractPendingInterrupt } from './approvalInterrupt'
 
-const APPROVAL_REQUIRED_STATUSES = new Set([
-  'ask_user_question_required',
-  'human_approval_required'
-])
-
-const extractQuestionPayload = (chunk) => {
-  const interruptInfo = chunk?.interrupt_info || {}
-  const rawQuestions = chunk?.questions || interruptInfo?.questions || []
-  const source = chunk?.source || interruptInfo?.source || 'interrupt'
-  const questions = normalizeQuestions(rawQuestions)
-
-  return {
-    questions,
-    source
-  }
-}
-
-export const extractPendingInterrupt = (chunk, threadId) => {
-  const payload = extractQuestionPayload(chunk)
-  if (!payload.questions.length) return null
-
-  return {
-    questions: payload.questions,
-    source: payload.source,
-    status: chunk?.status || '',
-    threadId: chunk?.thread_id || threadId,
-    parentRunId: chunk?.run_id || chunk?.parent_run_id || null
-  }
-}
+export { extractPendingInterrupt }
 
 export function useApproval({ getThreadState, fetchThreadMessages }) {
   const approvalState = reactive({
     showModal: false,
+    kind: 'ask_user_question',
     questions: [],
+    actionRequests: [],
+    reviewConfigs: [],
     status: '',
     threadId: null,
     parentRunId: null
@@ -42,7 +17,10 @@ export function useApproval({ getThreadState, fetchThreadMessages }) {
 
   const applyInterruptToApprovalState = (pendingInterrupt, fallbackThreadId) => {
     approvalState.showModal = true
-    approvalState.questions = pendingInterrupt.questions
+    approvalState.kind = pendingInterrupt.kind || 'ask_user_question'
+    approvalState.questions = pendingInterrupt.questions || []
+    approvalState.actionRequests = pendingInterrupt.actionRequests || []
+    approvalState.reviewConfigs = pendingInterrupt.reviewConfigs || []
     approvalState.status = pendingInterrupt.status || ''
     approvalState.threadId = pendingInterrupt.threadId || fallbackThreadId
     approvalState.parentRunId = pendingInterrupt.parentRunId || null
@@ -50,17 +28,16 @@ export function useApproval({ getThreadState, fetchThreadMessages }) {
 
   const clearApprovalState = () => {
     approvalState.showModal = false
+    approvalState.kind = 'ask_user_question'
     approvalState.questions = []
+    approvalState.actionRequests = []
+    approvalState.reviewConfigs = []
     approvalState.status = ''
     approvalState.threadId = null
     approvalState.parentRunId = null
   }
 
   const processApprovalInStream = (chunk, threadId, currentAgentId) => {
-    if (!APPROVAL_REQUIRED_STATUSES.has(chunk.status)) {
-      return false
-    }
-
     const threadState = getThreadState(threadId)
     if (!threadState) return false
 
@@ -80,7 +57,11 @@ export function useApproval({ getThreadState, fetchThreadMessages }) {
   const restoreInterruptFromThreadState = (threadId) => {
     const threadState = getThreadState(threadId)
     const pendingInterrupt = threadState?.pendingInterrupt
-    if (!pendingInterrupt?.questions?.length) return false
+    if (!pendingInterrupt) return false
+    // 两种 kind 都需要恢复(questions 或 actionRequests 至少一个非空)
+    if (!pendingInterrupt.questions?.length && !pendingInterrupt.actionRequests?.length) {
+      return false
+    }
 
     threadState.isStreaming = false
     threadState.replyLoadingVisible = false


### PR DESCRIPTION
## 说明

本 PR 是 #784 的干净重新提交。

#784 误夹带了与 HIL 修复无关的本地定制 commit(logo / 首页 / 登录页 / 配置等),已被关闭。本 PR 仅保留 HIL 工具审批相关的改动。

## 改动内容

**后端**
- 修复 HIL 工具审批 interrupt 在后端三处被误当 `ask_user_question` 处理(`agent_run_service` / `chat_service` / `run_worker`)
- 补充 `test_agent_run_service` / `test_chat_stream_interrupt` 单测

**前端**
- 新增 `HumanToolApprovalModal.vue` 工具审批弹窗,支持 approve / reject / edit
- 新增 `approvalInterrupt.js`,调整 `useApproval.js` / `useAgentRunStream.js` / `AgentChatComponent.vue` 接入审批弹窗

Supersedes #784