### PR TITLE
fix(graph): 从子图结果中过滤掉悬边

### DIFF
--- a/backend/package/yuxi/knowledge/graphs/milvus_graph_service.py
+++ b/backend/package/yuxi/knowledge/graphs/milvus_graph_service.py
@@ -880,6 +880,7 @@ class MilvusGraphService:
     def _finalize_subgraph_result(
         nodes: list[dict[str, Any]], edges: list[dict[str, Any]], limit: int
     ) -> dict[str, Any]:
+        limit = max(0, limit)
         final_nodes = nodes[:limit]
         node_ids = {node["id"] for node in final_nodes}
         final_edges = [

--- a/backend/package/yuxi/knowledge/graphs/milvus_graph_service.py
+++ b/backend/package/yuxi/knowledge/graphs/milvus_graph_service.py
@@ -848,7 +848,7 @@ class MilvusGraphService:
             if len(nodes) >= limit:
                 break
 
-        return {"nodes": nodes[:limit], "edges": edges[: limit * 2]}
+        return self._finalize_subgraph_result(nodes, edges, limit)
 
     def _process_subgraph_record(self, record: Any, limit: int, kb_id: str) -> dict[str, Any]:
         nodes = []
@@ -874,7 +874,20 @@ class MilvusGraphService:
             edges.append(edge)
             edge_ids.add(edge["id"])
 
-        return {"nodes": nodes, "edges": edges}
+        return self._finalize_subgraph_result(nodes, edges, limit)
+
+    @staticmethod
+    def _finalize_subgraph_result(
+        nodes: list[dict[str, Any]], edges: list[dict[str, Any]], limit: int
+    ) -> dict[str, Any]:
+        final_nodes = nodes[:limit]
+        node_ids = {node["id"] for node in final_nodes}
+        final_edges = [
+            edge
+            for edge in edges
+            if edge.get("source_id") in node_ids and edge.get("target_id") in node_ids
+        ]
+        return {"nodes": final_nodes, "edges": final_edges[: limit * 2]}
 
     def _normalize_node(self, raw_node: Any, kb_id: str | None = None) -> dict[str, Any]:
         if hasattr(raw_node, "element_id"):

--- a/backend/test/unit/graphs/test_milvus_graph_build.py
+++ b/backend/test/unit/graphs/test_milvus_graph_build.py
@@ -290,6 +290,23 @@ def test_milvus_graph_service_process_query_result_filters_edges_to_excluded_chu
     assert result["edges"] == []
 
 
+def test_milvus_graph_service_process_query_result_clamps_negative_limit():
+    service = MilvusGraphService()
+    result = service._process_query_result(
+        [
+            {
+                "h": _raw_graph_node("node-a"),
+                "t": _raw_graph_node("node-b"),
+                "r": _raw_graph_edge("edge-a-b", "node-a", "node-b"),
+            }
+        ],
+        limit=-1,
+        kb_id="kb_test",
+    )
+
+    assert result == {"nodes": [], "edges": []}
+
+
 @pytest.mark.asyncio
 async def test_milvus_graph_service_query_nodes_empty_kb_id():
     service = MilvusGraphService()

--- a/backend/test/unit/graphs/test_milvus_graph_build.py
+++ b/backend/test/unit/graphs/test_milvus_graph_build.py
@@ -13,6 +13,24 @@ from yuxi.knowledge.graphs.extractors import (
 from yuxi.knowledge.graphs.milvus_graph_service import MilvusGraphService
 
 
+def _raw_graph_node(node_id: str, *, labels: list[str] | None = None, name: str | None = None) -> dict:
+    return {
+        "id": node_id,
+        "labels": labels or ["MilvusKB", "Entity"],
+        "properties": {"name": name or node_id, "kb_id": "kb_test"},
+    }
+
+
+def _raw_graph_edge(edge_id: str, source_id: str, target_id: str) -> dict:
+    return {
+        "id": edge_id,
+        "type": "RELATED_TO",
+        "source_id": source_id,
+        "target_id": target_id,
+        "properties": {},
+    }
+
+
 def test_normalize_extraction_result_defaults_and_validates_refs():
     result = normalize_extraction_result(
         {
@@ -215,6 +233,61 @@ def test_milvus_graph_service_writes_chunk_entity_and_relation():
     assert any("MERGE (source)-[r:RELATION" in query for query in queries)
     entity_call = next(call for call in tx.run.call_args_list if "MERGE (e:Entity" in call.args[0])
     assert entity_call.kwargs["attributes"] == '[{"text": "工程师", "label": "Occupation"}]'
+
+
+def test_milvus_graph_service_process_query_result_keeps_complete_edges():
+    service = MilvusGraphService()
+    result = service._process_query_result(
+        [
+            {
+                "h": _raw_graph_node("node-a"),
+                "t": _raw_graph_node("node-b"),
+                "r": _raw_graph_edge("edge-a-b", "node-a", "node-b"),
+            }
+        ],
+        limit=2,
+        kb_id="kb_test",
+    )
+
+    assert [node["id"] for node in result["nodes"]] == ["node-a", "node-b"]
+    assert [edge["id"] for edge in result["edges"]] == ["edge-a-b"]
+
+
+def test_milvus_graph_service_process_query_result_filters_edges_after_node_limit():
+    service = MilvusGraphService()
+    result = service._process_query_result(
+        [
+            {
+                "h": _raw_graph_node("node-a"),
+                "t": _raw_graph_node("node-b"),
+                "r": _raw_graph_edge("edge-a-b", "node-a", "node-b"),
+            }
+        ],
+        limit=1,
+        kb_id="kb_test",
+    )
+
+    assert [node["id"] for node in result["nodes"]] == ["node-a"]
+    assert result["edges"] == []
+
+
+def test_milvus_graph_service_process_query_result_filters_edges_to_excluded_chunk_nodes():
+    service = MilvusGraphService()
+    result = service._process_query_result(
+        [
+            {
+                "h": _raw_graph_node("entity-a"),
+                "t": _raw_graph_node("chunk-a", labels=["MilvusKB", "Chunk"]),
+                "r": _raw_graph_edge("edge-entity-chunk", "entity-a", "chunk-a"),
+            }
+        ],
+        limit=2,
+        kb_id="kb_test",
+        exclude_chunk=True,
+    )
+
+    assert [node["id"] for node in result["nodes"]] == ["entity-a"]
+    assert result["edges"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更描述

修复 Milvus 知识图谱子图查询结果中可能返回“悬空边”的问题。

在 `/graph/subgraph` 返回数据时，如果节点数量被 `limit` 截断，或开启 `exclude_chunk=True` 过滤掉 Chunk 节点，原逻辑可能仍然保留指向已被移除节点的边，导致前端收到的 graph payload 中存在 source/target 不完整的 edge。

本 PR 在 `MilvusGraphService` 中统一收口子图返回结果：先确定最终返回的节点集合，再过滤掉 source 或 target 不在该节点集合中的边，从而保证返回的每条边都能在 `nodes` 中找到两端节点。

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [x] 相关功能正常工作

**相关日志或者截图**

```text
uv run python -m pytest test/unit/graphs/test_milvus_graph_build.py -q
18 passed, 2 warnings in 10.58s

uv run ruff check package/yuxi/knowledge/graphs/milvus_graph_service.py test/unit/graphs/test_milvus_graph_build.py
All checks passed!

uv run python -m py_compile package/yuxi/knowledge/graphs/milvus_graph_service.py test/unit/graphs/test_milvus_graph_build.py
```

新增测试覆盖：
- 完整节点和边都存在时，正常保留 edge；
- `limit` 截断掉边的端点节点后，过滤该 edge；
- `exclude_chunk=True` 过滤 Chunk 节点后，过滤指向 Chunk 的 edge；
- `limit < 0` 时按 0 处理，避免 Python 负数切片导致非预期节点返回。

## 说明

本地环境已按项目依赖使用 `uv` 同步并运行目标单测与 ruff 检查。

本 PR 没有修改对外 API 结构，只在返回前保证子图数据满足“不返回悬空边”的一致性约束。`_process_query_result()` 和 `_process_subgraph_record()` 复用同一个私有 helper，避免两个查询路径出现不一致行为。