### PR TITLE
fix: materialize multimodal images for sandbox tools

### DIFF
--- a/backend/package/yuxi/agents/base.py
+++ b/backend/package/yuxi/agents/base.py
@@ -273,8 +273,15 @@ class BaseAgent:
             with suppress(asyncio.CancelledError):
                 await route_task
 
-    async def stream_messages_with_state(self, messages: list[str], input_context=None, **kwargs):
-        async for event in self._stream_input_with_state({"messages": messages}, input_context, **kwargs):
+    async def stream_messages_with_state(
+        self,
+        messages: list[str],
+        input_context=None,
+        state_updates: dict[str, Any] | None = None,
+        **kwargs,
+    ):
+        graph_input = {**(state_updates or {}), "messages": messages}
+        async for event in self._stream_input_with_state(graph_input, input_context, **kwargs):
             yield event
 
     async def stream_resume_with_state(self, resume_input, input_context=None, **kwargs):

--- a/backend/package/yuxi/services/chat_service.py
+++ b/backend/package/yuxi/services/chat_service.py
@@ -29,7 +29,7 @@ from yuxi.repositories.agent_repository import AgentRepository
 from yuxi.repositories.agent_run_repository import AgentRunRepository
 from yuxi.repositories.conversation_repository import ConversationRepository
 from yuxi.repositories.subagent_thread_repository import SubagentThreadRepository
-from yuxi.services.conversation_service import serialize_attachment
+from yuxi.services.conversation_service import materialize_inline_image_upload, serialize_attachment
 from yuxi.services.input_message_service import AgentRunInputMessage
 from yuxi.services.langfuse_service import (
     LangfuseRunContext,
@@ -384,6 +384,37 @@ async def _stream_agent_events(agent, messages, *, input_context=None, **kwargs)
         **kwargs,
     ):
         yield mode, payload
+
+
+def _merge_uploads(existing_uploads: list[dict], current_uploads: list[dict]) -> list[dict]:
+    merged: list[dict] = []
+    positions: dict[tuple[str, str], int] = {}
+    for upload in [*existing_uploads, *current_uploads]:
+        if not isinstance(upload, dict):
+            continue
+        identity = next(
+            (
+                (field, str(upload[field]))
+                for field in ("file_id", "path")
+                if upload.get(field) is not None and str(upload[field]).strip()
+            ),
+            None,
+        )
+        if identity is not None and identity in positions:
+            merged[positions[identity]] = upload
+            continue
+        if identity is not None:
+            positions[identity] = len(merged)
+        merged.append(upload)
+    return merged
+
+
+async def _merge_checkpoint_uploads(agent, *, context, config: dict, current_uploads: list[dict]) -> list[dict]:
+    graph = await agent.get_graph(context=context)
+    snapshot = await graph.aget_state(config)
+    values = snapshot.values if snapshot and isinstance(snapshot.values, dict) else {}
+    existing_uploads = values.get("uploads") if isinstance(values.get("uploads"), list) else []
+    return _merge_uploads(existing_uploads, current_uploads)
 
 
 async def _get_existing_message_ids(conv_repo: ConversationRepository, thread_id: str) -> set[str]:
@@ -875,6 +906,16 @@ async def stream_agent_chat(
             request_id=meta["request_id"],
             attachment_file_ids=_normalize_attachment_file_ids(meta),
         )
+        runtime_uploads = list(request_attachments)
+        if image_content:
+            runtime_uploads.append(
+                await materialize_inline_image_upload(
+                    thread_id=thread_id,
+                    uid=uid,
+                    image_content=image_content,
+                    request_id=meta["request_id"],
+                )
+            )
 
         init_msg = {
             "role": "user",
@@ -910,14 +951,22 @@ async def stream_agent_chat(
         # 先构建 langgraph_config
         langgraph_config = {"configurable": {"thread_id": thread_id, "uid": uid}}
 
-        # LangGraph 会自动从 checkpointer 恢复 state（包括 uploads）
-        # 无需手动加载或传递
+        # Inline images are added to this run's uploads state so file tools receive a real sandbox path.
 
         protocol_message_ids: dict[tuple[str, str], str] = {}
+        if image_content:
+            runtime_uploads = await _merge_checkpoint_uploads(
+                agent,
+                context=context,
+                config=langgraph_config,
+                current_uploads=runtime_uploads,
+            )
+        state_updates = {"uploads": runtime_uploads} if image_content else None
         async for mode, payload in _stream_agent_events(
             agent,
             messages,
             input_context=input_context,
+            state_updates=state_updates,
             callbacks=langfuse_run.callbacks,
             metadata=langfuse_run.metadata,
             tags=langfuse_run.tags,

--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -1,3 +1,7 @@
+import asyncio
+import base64
+import binascii
+import hashlib
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -283,6 +287,52 @@ def serialize_attachment(record: dict) -> dict:
         "original_artifact_url": record.get("original_artifact_url"),
         "minio_url": record.get("minio_url"),
         "request_id": record.get("request_id"),
+    }
+
+
+async def materialize_inline_image_upload(
+    *,
+    thread_id: str,
+    uid: str,
+    image_content: str,
+    request_id: str | None = None,
+) -> dict:
+    """Persist an inline chat image in the thread sandbox for file tools."""
+    try:
+        image_bytes = base64.b64decode(image_content, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("invalid inline image content") from exc
+
+    if not image_bytes:
+        raise ValueError("inline image content is empty")
+    if len(image_bytes) > MAX_ATTACHMENT_SIZE_BYTES:
+        raise ValueError("inline image exceeds the 5 MB attachment limit")
+
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        suffix, file_type = ".png", "image/png"
+    else:
+        suffix, file_type = ".jpg", "image/jpeg"
+
+    file_id = hashlib.sha256(image_bytes).hexdigest()
+    file_name = f"{file_id}{suffix}"
+    ensure_thread_dirs(thread_id, uid)
+    virtual_path = _make_upload_virtual_path(file_name)
+    storage_path = sandbox_uploads_dir(thread_id) / file_name
+    await asyncio.to_thread(storage_path.write_bytes, image_bytes)
+
+    return {
+        "file_id": file_id,
+        "file_name": file_name,
+        "file_type": file_type,
+        "file_size": len(image_bytes),
+        "status": "uploaded",
+        "uploaded_at": utc_isoformat(),
+        "path": virtual_path,
+        "artifact_url": _artifact_url(thread_id, virtual_path),
+        "original_path": virtual_path,
+        "original_artifact_url": _artifact_url(thread_id, virtual_path),
+        "storage_path": str(storage_path),
+        "request_id": request_id,
     }
 
 

--- a/backend/test/unit/agents/test_base_agent_stream_state.py
+++ b/backend/test/unit/agents/test_base_agent_stream_state.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from yuxi.agents.base import BaseAgent
+
+
+@pytest.mark.asyncio
+async def test_stream_messages_with_state_merges_state_updates_into_graph_input():
+    captured: dict = {}
+
+    class CaptureAgent(BaseAgent):
+        async def _stream_input_with_state(self, graph_input, input_context=None, **kwargs):
+            captured["graph_input"] = graph_input
+            captured["input_context"] = input_context
+            captured["kwargs"] = kwargs
+            yield "values", graph_input
+
+    agent = object.__new__(CaptureAgent)
+    uploads = [{"path": "/home/gem/user-data/uploads/image.jpg"}]
+
+    events = [
+        event
+        async for event in agent.stream_messages_with_state(
+            ["hello"],
+            input_context={"thread_id": "thread-1"},
+            state_updates={"uploads": uploads},
+            callbacks=["callback-1"],
+        )
+    ]
+
+    assert captured["graph_input"] == {"messages": ["hello"], "uploads": uploads}
+    assert captured["input_context"] == {"thread_id": "thread-1"}
+    assert captured["kwargs"] == {"callbacks": ["callback-1"]}
+    assert events == [("values", {"messages": ["hello"], "uploads": uploads})]

--- a/backend/test/unit/services/test_chat_service_langfuse_stream.py
+++ b/backend/test/unit/services/test_chat_service_langfuse_stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 from types import SimpleNamespace
 
@@ -7,6 +8,7 @@ import pytest
 from langchain.messages import AIMessageChunk, HumanMessage
 
 from yuxi.services import chat_service as svc
+from yuxi.services import conversation_service as conversation_svc
 from yuxi.services.input_message_service import build_chat_input_message
 
 
@@ -130,7 +132,9 @@ def test_build_langfuse_run_context_reads_evaluation_from_invocation_meta(monkey
 
 
 @pytest.mark.asyncio
-async def test_stream_agent_chat_passes_langfuse_callbacks_and_persists_trace_info(monkeypatch: pytest.MonkeyPatch):
+async def test_stream_agent_chat_passes_langfuse_callbacks_and_persists_trace_info(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     calls: dict[str, object] = {}
 
     class FakeAgent:
@@ -145,7 +149,20 @@ async def test_stream_agent_chat_passes_langfuse_callbacks_and_persists_trace_in
         async def get_graph(self, *, context=None):
             class FakeGraph:
                 async def aget_state(self, config):
-                    return SimpleNamespace(values={"messages": [], "files": {}, "artifacts": []})
+                    return SimpleNamespace(
+                        values={
+                            "messages": [],
+                            "files": {},
+                            "artifacts": [],
+                            "uploads": [
+                                {
+                                    "file_id": "existing-file",
+                                    "file_name": "existing.pdf",
+                                    "path": "/home/gem/user-data/uploads/existing.pdf",
+                                }
+                            ],
+                        }
+                    )
 
             return FakeGraph()
 
@@ -201,13 +218,16 @@ async def test_stream_agent_chat_passes_langfuse_callbacks_and_persists_trace_in
         },
     )
     monkeypatch.setattr(svc, "flush_langfuse", lambda: calls.setdefault("flushed", True))
+    monkeypatch.setattr(conversation_svc.app_config, "save_dir", str(tmp_path))
+
+    image_bytes = b"\xff\xd8inline-image\xff\xd9"
 
     chunks = []
     async for chunk in svc.stream_agent_chat(
         agent_slug="test-agent",
         thread_id="thread-1",
         meta={"request_id": "req-1"},
-        input_message=build_chat_input_message("hello"),
+        input_message=build_chat_input_message("hello", base64.b64encode(image_bytes).decode("ascii")),
         current_user=SimpleNamespace(id=1, uid="user-1", role="user", department_id="dept-1"),
         db=object(),
     ):
@@ -220,10 +240,18 @@ async def test_stream_agent_chat_passes_langfuse_callbacks_and_persists_trace_in
         "run_id": None,
         "request_id": "req-1",
     }
+    existing_upload, inline_upload = calls["stream_kwargs"]["state_updates"]["uploads"]
+    assert existing_upload["file_id"] == "existing-file"
+    assert inline_upload["path"].startswith("/home/gem/user-data/uploads/")
+    assert inline_upload["file_type"] == "image/jpeg"
+    assert (
+        tmp_path / "threads" / "thread-1" / "user-data" / "uploads" / inline_upload["file_name"]
+    ).read_bytes() == image_bytes
     assert calls["stream_kwargs"] == {
         "callbacks": ["handler-1"],
         "metadata": {"langfuse_user_id": "user-1", "langfuse_session_id": "thread-1"},
         "tags": ["yuxi", "chat"],
+        "state_updates": {"uploads": [existing_upload, inline_upload]},
     }
     assert calls["saved_state"]["trace_info"] == {
         "langfuse_trace_id": "trace-runtime",


### PR DESCRIPTION
## Summary

- materialize inline multimodal images into the current thread sandbox before agent execution
- inject the real virtual upload path into LangGraph state so OCR and other file tools can access it
- preserve existing checkpointed uploads when an image is added, with deduplication by file ID or path
- move image file writes off the async event loop

## Test plan

- `python -m pytest test/unit/services/test_chat_service_langfuse_stream.py test/unit/agents/test_base_agent_stream_state.py test/unit/services/test_chat_stream_attachment_materialize.py test/unit/services/test_conversation_service_attachment_state.py test/unit/toolkits/test_ocr_parse_file_tool.py -q` (22 passed)
- `ruff check` on all changed Python files
- `python -m compileall` on all changed Python files

Closes #812