### PR TITLE
fix(web): 修正设置弹窗 availableTabs 残留的 userConfig 旧 tab 名

### DIFF
--- a/web/src/components/SettingsModal.vue
+++ b/web/src/components/SettingsModal.vue
@@ -241,7 +241,7 @@ const visible = computed({
 
 const availableTabs = computed(() => {
   const tabs = []
-  if (userStore.isLoggedIn) tabs.push('account', 'userConfig', 'agentEnv')
+  if (userStore.isLoggedIn) tabs.push('account', 'apiKeys', 'agentEnv')
   if (userStore.isAdmin) tabs.push('base', 'user')
   if (userStore.isSuperAdmin) tabs.push('department')
   return tabs


### PR DESCRIPTION
## 问题

`629e83b4`(feat(web): 优化交互体验)将设置弹窗的 tab 从 `userConfig` 重命名为 `apiKeys`,渲染端已全部改为 `apiKeys`(行 33/124 `@click="activeTab = 'apiKeys'"`、行 171 `v-if="activeTab === 'apiKeys'"`),但 `availableTabs` 计算属性漏改,行 244 仍 push `'userConfig'`。

`availableTabs` 被 `setActiveTab` 用于判断 `initialTab` 是否有效:仅当 `availableTabs.includes(preferredTab)` 为真才跳转,否则 fallback 到默认 tab。由于列表里是 `'userConfig'` 而非 `'apiKeys'`,调用 `setActiveTab('apiKeys')` 会走 fallback,无法跳转到 API Keys tab。

## 修复

将 `availableTabs` 行 244 的 `'userConfig'` 改为 `'apiKeys'`,与渲染端一致。

## 验证

- 改后 `availableTabs` 含 `'apiKeys'`,与渲染端面板对应
- `setActiveTab('apiKeys')` 能正确跳转
- 旧的 `initialTab='userConfig'` 调用会走 fallback(不再空白,跳到默认 tab)
