### PR TITLE
fix(agent): 降低 Run SSE 数据库轮询压力 🤖

### DIFF
--- a/backend/package/yuxi/services/agent_run_service.py
+++ b/backend/package/yuxi/services/agent_run_service.py
@@ -54,6 +54,7 @@ from yuxi.utils.logging_config import logger
 SSE_HEARTBEAT_SECONDS = int(os.getenv("RUN_SSE_HEARTBEAT_SECONDS", "15"))  # SSE 连接空闲多久发送心跳
 SSE_MAX_CONNECTION_MINUTES = int(os.getenv("RUN_SSE_MAX_CONNECTION_MINUTES", "30"))  # SSE 连接最大持续时间
 SSE_POLL_INTERVAL_SECONDS = float(os.getenv("RUN_SSE_POLL_INTERVAL_SECONDS", "1.0"))  # SSE 轮询间隔
+SSE_DB_STATUS_CHECK_INTERVAL_SECONDS = 5.0
 RUN_PROGRESS_RECENT_EVENT_SCAN_LIMIT = 100
 RUN_PROGRESS_MESSAGE_LIMIT = 3
 RUN_PROGRESS_CONTENT_MAX_CHARS = 800
@@ -812,32 +813,32 @@ async def stream_agent_run_events(
     """按 SSE 格式读取 run 事件流；终结事件缺失时根据数据库状态补发 end。"""
     started_at = utc_now_naive()
     last_heartbeat_ts = started_at
-
     last_seq = normalize_after_seq(after_seq)
 
     try:
-        while True:
-            try:
-                async with pg_manager.get_async_session_context() as db:
-                    repo = AgentRunRepository(db)
-                    run = await repo.get_run_for_user(run_id, str(current_uid))
-                    if not run:
-                        yield _format_sse({"run_id": run_id, "message": "运行任务不存在"}, event="error")
-                        return
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning(f"Run SSE DB error for run {run_id}: {e}")
-                yield _format_sse(
-                    {
-                        "run_id": run_id,
-                        "message": "运行事件流暂时不可用，请重连",
-                        "reason": "db_error",
-                    },
-                    event="error",
-                )
+        try:
+            run = await _load_agent_run_for_sse(run_id, current_uid)
+            if not run:
+                yield _format_sse({"run_id": run_id, "message": "运行任务不存在"}, event="error")
                 return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Run SSE DB error for run {run_id}: {e}")
+            yield _format_sse(
+                {
+                    "run_id": run_id,
+                    "message": "运行事件流暂时不可用，请重连",
+                    "reason": "db_error",
+                },
+                event="error",
+            )
+            return
 
+        loop = asyncio.get_running_loop()
+        next_status_check_at = loop.time() + SSE_DB_STATUS_CHECK_INTERVAL_SECONDS
+
+        while True:
             try:
                 events = await list_run_stream_events(run_id, after_seq=last_seq, limit=200)
             except Exception as e:
@@ -869,7 +870,37 @@ async def stream_agent_run_events(
             if emitted_terminal:
                 return
 
-            if run.status in TERMINAL_RUN_STATUSES and not events:
+            now = utc_now_naive()
+            elapsed_seconds = (now - started_at).total_seconds()
+            timed_out = elapsed_seconds >= SSE_MAX_CONNECTION_MINUTES * 60
+            monotonic_now = loop.time()
+
+            if events:
+                next_status_check_at = monotonic_now + SSE_DB_STATUS_CHECK_INTERVAL_SECONDS
+
+            status_check_due = not events and monotonic_now >= next_status_check_at
+            if timed_out or (status_check_due and run.status not in TERMINAL_RUN_STATUSES):
+                try:
+                    run = await _load_agent_run_for_sse(run_id, current_uid)
+                    if not run:
+                        yield _format_sse({"run_id": run_id, "message": "运行任务不存在"}, event="error")
+                        return
+                    next_status_check_at = loop.time() + SSE_DB_STATUS_CHECK_INTERVAL_SECONDS
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning(f"Run SSE DB error for run {run_id}: {e}")
+                    yield _format_sse(
+                        {
+                            "run_id": run_id,
+                            "message": "运行事件流暂时不可用，请重连",
+                            "reason": "db_error",
+                        },
+                        event="error",
+                    )
+                    return
+
+            if run.status in TERMINAL_RUN_STATUSES and (not events or timed_out):
                 terminal_seq = last_seq
                 if terminal_seq in {"", "0-0"}:
                     terminal_seq = await get_last_run_stream_seq(run_id)
@@ -891,19 +922,22 @@ async def stream_agent_run_events(
                 )
                 return
 
-            now = utc_now_naive()
-            elapsed_seconds = (now - started_at).total_seconds()
             heartbeat_elapsed = (now - last_heartbeat_ts).total_seconds()
             if heartbeat_elapsed >= SSE_HEARTBEAT_SECONDS:
                 yield _format_heartbeat()
                 last_heartbeat_ts = now
 
-            if elapsed_seconds >= SSE_MAX_CONNECTION_MINUTES * 60:
+            if timed_out:
                 return
 
             await asyncio.sleep(SSE_POLL_INTERVAL_SECONDS)
     except asyncio.CancelledError:
         return
+
+
+async def _load_agent_run_for_sse(run_id: str, current_uid: str):
+    async with pg_manager.get_async_session_context() as db:
+        return await AgentRunRepository(db).get_run_for_user(run_id, str(current_uid))
 
 
 async def get_active_run_by_thread(*, thread_id: str, current_uid: str, db: AsyncSession) -> dict:

--- a/backend/test/unit/services/test_agent_run_service.py
+++ b/backend/test/unit/services/test_agent_run_service.py
@@ -445,6 +445,56 @@ async def test_stream_agent_run_events_reads_redis_and_ends_on_end_event(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_stream_agent_run_events_queries_db_once_while_redis_has_events(monkeypatch: pytest.MonkeyPatch):
+    session_count = 0
+
+    @asynccontextmanager
+    async def fake_session_ctx():
+        nonlocal session_count
+        session_count += 1
+        yield object()
+
+    class Repo:
+        def __init__(self, db):
+            self.db = db
+
+        async def get_run_for_user(self, run_id: str, uid: str):
+            del run_id, uid
+            return SimpleNamespace(status="running", conversation_thread_id="thread-1", request_id="req-1")
+
+    redis_read_count = 0
+
+    async def fake_list_events(run_id: str, *, after_seq: str, limit: int):
+        nonlocal redis_read_count
+        del run_id, after_seq, limit
+        redis_read_count += 1
+        return [
+            {
+                "seq": f"170000000000{redis_read_count}-0",
+                "event_type": "end" if redis_read_count == 3 else "metadata",
+                "payload": {"run_id": "run-1"},
+            }
+        ]
+
+    monkeypatch.setattr(agent_run_service.pg_manager, "get_async_session_context", fake_session_ctx)
+    monkeypatch.setattr(agent_run_service, "AgentRunRepository", Repo)
+    monkeypatch.setattr(agent_run_service, "list_run_stream_events", fake_list_events)
+    monkeypatch.setattr(agent_run_service, "SSE_POLL_INTERVAL_SECONDS", 0)
+
+    chunks = []
+    async for chunk in agent_run_service.stream_agent_run_events(
+        run_id="run-1",
+        after_seq="0-0",
+        current_uid="user-1",
+    ):
+        chunks.append(chunk)
+
+    assert redis_read_count == 3
+    assert session_count == 1
+    assert chunks[-1].startswith("event: end")
+
+
+@pytest.mark.asyncio
 async def test_stream_agent_run_events_compacts_verbose_false(monkeypatch: pytest.MonkeyPatch):
     @asynccontextmanager
     async def fake_session_ctx():
@@ -644,7 +694,17 @@ async def test_stream_agent_run_events_compacts_verbose_false(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
-async def test_stream_agent_run_events_compact_fallback_end_keeps_request_id(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    ("status_check_interval", "max_connection_minutes"),
+    [(0, 30), (999, 0)],
+)
+async def test_stream_agent_run_events_compact_fallback_end_keeps_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+    status_check_interval: float,
+    max_connection_minutes: int,
+):
+    query_count = 0
+
     @asynccontextmanager
     async def fake_session_ctx():
         yield object()
@@ -654,8 +714,14 @@ async def test_stream_agent_run_events_compact_fallback_end_keeps_request_id(mon
             self.db = db
 
         async def get_run_for_user(self, run_id: str, uid: str):
+            nonlocal query_count
             del run_id, uid
-            return SimpleNamespace(status="completed", conversation_thread_id="thread-1", request_id="req-1")
+            query_count += 1
+            return SimpleNamespace(
+                status="running" if query_count == 1 else "completed",
+                conversation_thread_id="thread-1",
+                request_id="req-1",
+            )
 
     async def fake_list_events(run_id: str, *, after_seq: str, limit: int):
         del run_id, after_seq, limit
@@ -669,6 +735,8 @@ async def test_stream_agent_run_events_compact_fallback_end_keeps_request_id(mon
     monkeypatch.setattr(agent_run_service, "AgentRunRepository", Repo)
     monkeypatch.setattr(agent_run_service, "list_run_stream_events", fake_list_events)
     monkeypatch.setattr(agent_run_service, "get_last_run_stream_seq", fake_get_last_run_stream_seq)
+    monkeypatch.setattr(agent_run_service, "SSE_DB_STATUS_CHECK_INTERVAL_SECONDS", status_check_interval)
+    monkeypatch.setattr(agent_run_service, "SSE_MAX_CONNECTION_MINUTES", max_connection_minutes)
 
     chunks = []
     async for chunk in agent_run_service.stream_agent_run_events(
@@ -683,6 +751,7 @@ async def test_stream_agent_run_events_compact_fallback_end_keeps_request_id(mon
     assert chunks[0].startswith("event: end")
     assert "id: 1700000000004-0" in chunks[0]
     data = _sse_data(chunks[0])
+    assert query_count == 2
     assert data["request_id"] == "req-1"
     assert data["payload"] == {"status": "completed"}
 

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -15,6 +15,8 @@
 
 ### 开发记录
 
+- 降低智能体 Run SSE 对 PostgreSQL 的轮询压力：SSE 建连时查询一次 run 完成存在性与归属校验，Redis 持续有事件时不再重复访问数据库；连续空闲 5 秒后才检查一次持久化状态，并在空闲期间每 5 秒复查，连接达到上限前执行最终检查。Redis 缺失 `end` 但数据库已进入终态时仍会补发终结事件，现有 SSE cursor、回放和 Redis 轮询协议保持不变。
+
 - 工作区 `agents` 目录新增 `USER.md` 与 `MEMORY.md` 上下文文件，并与 `AGENTS.md` 一起在 Agent 运行开始时加载；三个默认文件首次创建时均写入对应标题和说明，不再生成空文件，已有内容保持不变。
 - 新增 Summary 上下文压缩实时状态流式同步：`YuxiSummarizationMiddleware` 触发压缩时通过 `langgraph.config.get_stream_writer()` 推送 `yuxi.context_compression` 自定义事件（started/completed/failed），复用 DeepAgents 已有 `_summarization_event` 作为完成数据源；`base.py` 通过 `astream_events(version="v3")` 的 `CustomTransformer` 透传 custom 流，`chat_service`/`agent_run_service` 将事件映射为 `context_compression` chunk 并透传到前端；前端收到 `started` 时将"正在生成回复"加载态文案切换为"正在压缩上下文"，压缩结束（`completed`/`finished`）即切回，不额外渲染分隔符、不保留压缩完成态。为避免摘要 LLM 调用的 token 流被 LangGraph messages stream 捕获并广播成 phantom 摘要消息，重写 `_create_summary`/`_acreate_summary` 在摘要模型 invoke 的 config 上挂 `TAG_NOSTREAM`，让流式层在源头跳过该调用，主 messages 流天然只含用户可见回复，无需 `chat_service` 下游过滤（参考 DeerFlow 实现）。异步 L2 压缩路径的 `_aoffload_to_backend` 与 `_acreate_summary` 改回 `asyncio.gather` 并发执行，与 DeepAgents 父类一致，避免串行等待一次文件 I/O 与一次摘要 LLM 调用；两路复用 `_SUMMARY_SANITIZED_MESSAGES` 的 id 缓存。L1-only 调用若仍触发 provider context overflow，会回落到 L2 summary 后重试；`summary_tool_result_token_limit` 默认改为 300，并同时作为 L1 工具结果 offload 阈值和预览上限，L2 只消费 L1 视图，不再对工具结果做第二轮 offload；L2 摘要模型的待摘要历史输入上限改为与 `summary_threshold` 对齐，避免固定 4000 token 裁剪丢失早期历史；新增 `summary_l2_trigger_ratio` 管理 L1 后进入 L2 的比例阈值，默认 `0.4`。
 


### PR DESCRIPTION
## 变更描述

Agent Run SSE 当前在每次 Redis 轮询前都会创建一个数据库 Session，并查询一次 run 状态。默认 1 秒轮询间隔下，每个 SSE 客户端都会持续产生 PostgreSQL 查询和事务提交，即使 Redis 正在正常推送事件。

本 PR 将数据库访问收敛为：

- SSE 建连时查询一次 run，完成存在性与用户归属校验；
- Redis 持续有事件时不再重复查询数据库，并重置空闲计时；
- Redis 连续空闲 5 秒后检查一次持久化状态，空闲期间每 5 秒复查；
- SSE 达到最大连接时长前执行最终状态检查；
- 数据库已终结但 Redis 缺少 `end` 时，继续补发终结事件。

Redis Stream cursor、事件回放和 SSE 响应协议保持不变。

## 变更类型

- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试

- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

**相关日志或者截图**

```text
python -m pytest -q test/unit/services/test_agent_run_service.py
38 passed

ruff format --check ...
2 files already formatted

ruff check ...
All checks passed!
```

新增/调整的回归覆盖包括：

- Redis 持续产生事件时，整个 SSE 流只创建一次 DB Session；
- Redis 空闲达到检查间隔后，从 DB 发现终态并补发 `end`；
- SSE 超时退出前执行最终 DB 状态检查。

## 说明

- 本 PR 不改前端和 SSE 协议，无 UI 截图。
- PR 以 Draft 创建，等待 maintainer / human review。

---

<details>
<summary>贡献说明</summary>

本 PR 由 Codex 自动生成，且没有人工干预。
</details>
