### PR TITLE
fix: 修复智能体聊天图片解析时未使用系统默认 OCR 引擎的问题 🤖

### DIFF
--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -207,7 +207,7 @@ def _normalize_parse_method(file_name: str, parse_method: str | None) -> str:
     if suffix not in TMP_ATTACHMENT_PARSE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="当前仅支持 PDF 和图片附件解析")
 
-    method = parse_method or ("rapid_ocr" if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS else "disable")
+    method = parse_method or (app_config.default_ocr_engine if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS else "disable")
     if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
         allowed_methods = TMP_ATTACHMENT_OCR_METHODS
     else:

--- a/backend/test/unit/test_tmp_attachment_service.py
+++ b/backend/test/unit/test_tmp_attachment_service.py
@@ -349,3 +349,70 @@ async def test_confirm_tmp_thread_attachments_keeps_duplicate_names_separate(mon
     assert first["original_path"] != second["original_path"]
     assert (tmp_path / "threads" / "thread-1" / "user-data" / "uploads" / Path(first["original_path"]).name).read_bytes() == b"first"
     assert (tmp_path / "threads" / "thread-1" / "user-data" / "uploads" / Path(second["original_path"]).name).read_bytes() == b"second"
+
+
+@pytest.mark.asyncio
+async def test_parse_tmp_attachment_image_uses_default_ocr_engine_when_parse_method_is_none(monkeypatch):
+    """图片附件未指定 parse_method 时应使用系统默认 OCR 引擎。"""
+    fake_minio = FakeMinioClient()
+    object_name = "tmp/chat_attachments/user-1/tmp-1/original/demo.png"
+    fake_minio.objects[("knowledgebases", object_name)] = b"png-bytes"
+    monkeypatch.setattr(service, "get_minio_client", lambda: fake_minio)
+
+    parse_calls = []
+
+    async def fake_parse(source: str, params: dict | None = None) -> str:
+        parse_calls.append({"source": source, "params": params})
+        return "# parsed"
+
+    monkeypatch.setattr(service.Parser, "aparse", staticmethod(fake_parse))
+    monkeypatch.setattr(service.app_config, "default_ocr_engine", "mineru_ocr")
+
+    response = await service.parse_tmp_attachment_view(
+        object_name=object_name,
+        file_name="demo.png",
+        parse_method=None,
+        bucket_name="knowledgebases",
+        current_uid="user-1",
+    )
+
+    assert parse_calls == [
+        {
+            "source": f"minio://knowledgebases/{object_name}",
+            "params": {"ocr_engine": "mineru_ocr"},
+        }
+    ]
+    assert response["parse_method"] == "mineru_ocr"
+
+
+@pytest.mark.asyncio
+async def test_parse_tmp_attachment_pdf_defaults_to_disable_when_parse_method_is_none(monkeypatch):
+    """PDF 附件未指定 parse_method 时应默认禁用 OCR。"""
+    fake_minio = FakeMinioClient()
+    object_name = "tmp/chat_attachments/user-1/tmp-1/original/demo.pdf"
+    fake_minio.objects[("knowledgebases", object_name)] = b"pdf-bytes"
+    monkeypatch.setattr(service, "get_minio_client", lambda: fake_minio)
+
+    parse_calls = []
+
+    async def fake_parse(source: str, params: dict | None = None) -> str:
+        parse_calls.append({"source": source, "params": params})
+        return "# parsed"
+
+    monkeypatch.setattr(service.Parser, "aparse", staticmethod(fake_parse))
+
+    response = await service.parse_tmp_attachment_view(
+        object_name=object_name,
+        file_name="demo.pdf",
+        parse_method=None,
+        bucket_name="knowledgebases",
+        current_uid="user-1",
+    )
+
+    assert parse_calls == [
+        {
+            "source": f"minio://knowledgebases/{object_name}",
+            "params": {"ocr_engine": "disable"},
+        }
+    ]
+    assert response["parse_method"] == "disable"


### PR DESCRIPTION
## 变更描述

修复智能体聊天时，用户上传图片附件并调用 OCR 解析时，未使用系统管理员配置的默认 OCR 引擎的问题。

在  的  函数中，当图片附件未指定  时，默认 OCR 引擎被硬编码为 ，而非读取系统配置 。这导致即使管理员在系统设置中将默认 OCR 引擎改为其他引擎（如 ），图片解析仍强制使用 。

## 变更类型
- [x] Bug 修复

## 修改内容

- : 将硬编码的  替换为 
- : 补充 2 个单元测试验证默认行为

## 测试
- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

新增测试：
-  — 验证图片未指定 parse_method 时使用系统默认 OCR 引擎
-  — 验证 PDF 未指定 parse_method 时仍为 disable

10 个单元测试全部通过。