### PR TITLE
fix: 临时附件图片解析默认使用系统配置的OCR引擎

### DIFF
--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -207,7 +207,11 @@ def _normalize_parse_method(file_name: str, parse_method: str | None) -> str:
     if suffix not in TMP_ATTACHMENT_PARSE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="当前仅支持 PDF 和图片附件解析")
 
-    method = parse_method or ("rapid_ocr" if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS else "disable")
+    if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
+        default_engine = app_config.default_ocr_engine
+        method = parse_method or ("rapid_ocr" if default_engine == "disable" else default_engine)
+    else:
+        method = parse_method or "disable"
     if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
         allowed_methods = TMP_ATTACHMENT_OCR_METHODS
     else:

--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -207,19 +207,13 @@ def _normalize_parse_method(file_name: str, parse_method: str | None) -> str:
     if suffix not in TMP_ATTACHMENT_PARSE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="当前仅支持 PDF 和图片附件解析")
 
-    if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
-        default_engine = app_config.default_ocr_engine
-        method = parse_method or ("rapid_ocr" if default_engine == "disable" else default_engine)
-    else:
-        method = parse_method or "disable"
-    if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
-        allowed_methods = TMP_ATTACHMENT_OCR_METHODS
-    else:
-        allowed_methods = TMP_ATTACHMENT_PARSE_METHODS
+    default_engine = app_config.default_ocr_engine
+    method = parse_method or ("rapid_ocr" if default_engine == "disable" else default_engine)
 
-    if method not in allowed_methods:
+    if method not in TMP_ATTACHMENT_OCR_METHODS:
         allowed = ", ".join(allowed_methods)
         raise HTTPException(status_code=400, detail=f"不支持的解析方法: {method}，可选: {allowed}")
+
     return method
 
 

--- a/backend/package/yuxi/services/conversation_service.py
+++ b/backend/package/yuxi/services/conversation_service.py
@@ -207,13 +207,19 @@ def _normalize_parse_method(file_name: str, parse_method: str | None) -> str:
     if suffix not in TMP_ATTACHMENT_PARSE_EXTENSIONS:
         raise HTTPException(status_code=400, detail="当前仅支持 PDF 和图片附件解析")
 
-    default_engine = app_config.default_ocr_engine
-    method = parse_method or ("rapid_ocr" if default_engine == "disable" else default_engine)
+    if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
+        default_engine = app_config.default_ocr_engine
+        method = parse_method or ("rapid_ocr" if default_engine == "disable" else default_engine)
+    else:
+        method = parse_method or "disable"
+    if suffix in TMP_ATTACHMENT_IMAGE_EXTENSIONS:
+        allowed_methods = TMP_ATTACHMENT_OCR_METHODS
+    else:
+        allowed_methods = TMP_ATTACHMENT_PARSE_METHODS
 
-    if method not in TMP_ATTACHMENT_OCR_METHODS:
+    if method not in allowed_methods:
         allowed = ", ".join(allowed_methods)
         raise HTTPException(status_code=400, detail=f"不支持的解析方法: {method}，可选: {allowed}")
-
     return method
 
 

--- a/backend/test/unit/services/test_conversation_service_attachment_state.py
+++ b/backend/test/unit/services/test_conversation_service_attachment_state.py
@@ -159,3 +159,33 @@ async def test_convert_upload_to_markdown_rejects_unsupported_extension(monkeypa
 
     with pytest.raises(ValueError, match="不支持的文件类型"):
         await svc._convert_upload_to_markdown(upload)
+
+
+def test_normalize_parse_method_uses_default_ocr_engine_for_images(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(svc.app_config, "default_ocr_engine", "mineru_ocr")
+    method = svc._normalize_parse_method("scan.png", parse_method=None)
+    assert method == "mineru_ocr"
+
+
+def test_normalize_parse_method_uses_default_ocr_engine_for_images_fallback_to_rapid(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(svc.app_config, "default_ocr_engine", "deepseek_ocr")
+    method = svc._normalize_parse_method("scan.jpg", parse_method=None)
+    assert method == "deepseek_ocr"
+
+
+def test_normalize_parse_method_pdf_defaults_to_disable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(svc.app_config, "default_ocr_engine", "mineru_ocr")
+    method = svc._normalize_parse_method("doc.pdf", parse_method=None)
+    assert method == "disable"
+
+
+def test_normalize_parse_method_respects_explicit_parse_method(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(svc.app_config, "default_ocr_engine", "rapid_ocr")
+    method = svc._normalize_parse_method("scan.png", parse_method="deepseek_ocr")
+    assert method == "deepseek_ocr"
+
+
+def test_normalize_parse_method_fallback_to_rapid_when_default_is_disable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(svc.app_config, "default_ocr_engine", "disable")
+    method = svc._normalize_parse_method("scan.png", parse_method=None)
+    assert method == "rapid_ocr"


### PR DESCRIPTION
## 变更描述
修复 conversation_service 中 _normalize_parse_method 在未指定 parse_method 时， 图片附件硬编码使用 rapid_ocr 的问题，改为读取 app_config.default_ocr_engine。

简要描述这个 PR 做了什么
修复了backend/package/yuxi/services/conversation_service.py

## 变更类型
- [ ] Bug 修复

## 测试
- [ ] 已在 Docker 环境测试
- [ ] 相关功能正常工作



