### PR TITLE
[codex] 忽略语义分块中的空标题

### DIFF
--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/parsers/semantic.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/parsers/semantic.py
@@ -162,8 +162,8 @@ def chunk_markdown(
     while i < len(tokens):
         token = tokens[i]
         if token.type == "heading_open":
-            inline_token = tokens[i + 1]
-            full_title = inline_token.content.strip() if inline_token.type == "inline" else ""
+            inline_token = tokens[i + 1] if i + 1 < len(tokens) else None
+            full_title = inline_token.content.strip() if inline_token and inline_token.type == "inline" else ""
             if not full_title:
                 i += 3
                 continue

--- a/backend/package/yuxi/knowledge/chunking/ragflow_like/parsers/semantic.py
+++ b/backend/package/yuxi/knowledge/chunking/ragflow_like/parsers/semantic.py
@@ -162,14 +162,17 @@ def chunk_markdown(
     while i < len(tokens):
         token = tokens[i]
         if token.type == "heading_open":
+            inline_token = tokens[i + 1]
+            full_title = inline_token.content.strip() if inline_token.type == "inline" else ""
+            if not full_title:
+                i += 3
+                continue
+
             _flush_content(result, current_content, title_stack, max_length, embed_fn)
             level = int(token.tag[1:]) if token.tag and len(token.tag) > 1 else 1
-            inline_token = tokens[i + 1]
-            if inline_token.type == "inline":
-                full_title = inline_token.content.strip()
-                title_stack[level - 1] = full_title
-                for j in range(level, 6):
-                    title_stack[j] = ""
+            title_stack[level - 1] = full_title
+            for j in range(level, 6):
+                title_stack[j] = ""
             i += 3
             continue
         elif token.type == "table_open":

--- a/backend/test/unit/backends/test_semantic_chunking_empty_heading.py
+++ b/backend/test/unit/backends/test_semantic_chunking_empty_heading.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from yuxi.knowledge.chunking.ragflow_like.parsers import semantic
 
 
@@ -24,3 +26,11 @@ Content after empty heading.
     assert chunks[0].splitlines()[0] == "### Parent Section|Child Section"
     assert "Content before empty heading." in chunks[0]
     assert "Content after empty heading." in chunks[0]
+
+
+def test_truncated_heading_token_stream_is_ignored(monkeypatch):
+    markdown_parser = semantic.MarkdownIt("commonmark")
+    monkeypatch.setattr(markdown_parser, "parse", lambda _: [SimpleNamespace(type="heading_open")])
+    monkeypatch.setattr(semantic, "MarkdownIt", lambda _: markdown_parser)
+
+    assert semantic.chunk_markdown("#", embed_fn=lambda texts: texts) == []

--- a/backend/test/unit/backends/test_semantic_chunking_empty_heading.py
+++ b/backend/test/unit/backends/test_semantic_chunking_empty_heading.py
@@ -1,0 +1,26 @@
+from yuxi.knowledge.chunking.ragflow_like.parsers import semantic
+
+
+def test_empty_heading_preserves_current_title_context():
+    markdown_content = """
+## Parent Section
+
+### Child Section
+
+Content before empty heading.
+
+###
+
+Content after empty heading.
+"""
+
+    chunks = semantic.chunk_markdown(
+        markdown_content,
+        parser_config={"chunk_token_num": 512},
+        embed_fn=lambda texts: texts,
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].splitlines()[0] == "### Parent Section|Child Section"
+    assert "Content before empty heading." in chunks[0]
+    assert "Content after empty heading." in chunks[0]


### PR DESCRIPTION
## 变更内容

- Semantic 分块器遇到空 Markdown 标题时直接忽略该标题。
- 空标题不再清空当前标题路径，也不会无意义地截断前后正文。
- 增加独立单元测试覆盖父标题、子标题、空标题与前后正文场景。

## 问题原因

HTML 转 Markdown 等处理可能产生空 ATX 标题，例如 `###`。MarkdownIt 会将其解析为标题节点，但标题内容为空。原实现仍会刷新当前内容并用空字符串更新标题栈，导致后续 Chunk 丢失有效的子标题上下文。

## 影响

仅改变空标题这一退化输入的处理方式；正常非空标题的分块和标题路径行为保持不变。

## 验证

- `21 passed, 1 skipped`：Semantic 与 RagFlow-like 相关单元测试。
- Ruff 检查通过。
- Ruff 格式检查通过。
- `git diff --check` 通过。
