### PR TITLE
增加 yuxi chat 本地网页聊天与 Interrupt/IM 方案 🤖

### DIFF
--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -6,6 +6,7 @@
 
 ## v0.7.2 (current)
 
+- CLI 新增 `yuxi chat` 本地网页调试入口：临时服务仅监听 `127.0.0.1`，使用本地保存的 remote 与 API Key 代理 Agent Call 和 Run SSE，浏览器可连续对话并实时显示文本增量；API Key 不进入页面，支持指定智能体、remote 及仅打印地址。
 - 优化知识图谱构建：以持续队列并发执行 LLM 抽取、结构写入和向量索引，失败自动重试并持久化进度；已有结果支持断点恢复，新增按最近 Chunk 查询失败样例和向量 reconcile 接口，任务与前端分别展示抽取、结构、向量进度，索引面板支持键盘操作。
 - HTML 辅助可视化迁移为内置 `html-preview` Skill：默认 Chatbot Prompt 不再常驻注入 `html:preview` 专属说明，Agent 改为通过统一的 Skill 描述发现并按需读取静态 HTML/CSS 的适用场景、布局和安全边界；未显式配置 Skills 的 Agent 按现有默认规则自动获得该能力，使用显式 Skills 允许列表的 Agent 需选择 `html-preview`，内置 `deep-research` 已声明依赖；保留前端既有围栏清洗、sandboxed iframe、自适应高度和流式占位行为，普通 HTML 源码继续使用 `html` 代码块。
 - 模型供应商的单个 chat 模型配置新增“模型请求参数 JSON”：管理员可为每个模型独立保存、回显、修改和清空思考参数，未配置或空对象保持原行为；运行时模型缓存会携带该配置，测试模型连接与正式聊天/Agent 调用统一在模型加载入口合并。该字段仅面向 OpenAI/OpenRouter 等 OpenAI 兼容供应商，并通过 `extra_body` 透传；出于安全考虑，顶层字段采用白名单机制，当前支持 `enable_thinking`、`thinking_budget`、`thinking`、`reasoning` 和 `reasoning_effort`，对象内部结构交由供应商校验。

--- a/docs/intro/cli.md
+++ b/docs/intro/cli.md
@@ -52,6 +52,25 @@ yuxi status
 yuxi logout
 ```
 
+## 本地网页聊天
+
+运行下面的命令会在 `127.0.0.1` 的随机端口启动一个临时网页，并自动在浏览器中打开：
+
+```bash
+yuxi chat
+```
+
+该网页通过 CLI 代理当前 remote 的 Agent API，使用已经保存在本地的 API Key，并流式显示回答。API Key 不会发送到浏览器。关闭终端中的进程后，本地网页服务随即停止。
+
+默认调用 `default-chatbot`，也可以指定其他智能体或 remote：
+
+```bash
+yuxi chat --agent-slug my-agent
+yuxi chat --remote production
+```
+
+在不能自动打开浏览器的环境中，可使用 `yuxi chat --no-open`，然后手动访问终端打印的本地地址。当前页面定位为基础调试工具，仅支持文本对话和新建会话；附件、工具审批等完整能力仍需使用正式 Web 界面。
+
 ## 上传知识库文件
 
 上传目录时，如果不指定 `--kb-id`，CLI 会拉取当前 remote 中可用的知识库并在终端中选择：

--- a/docs/vibe/2026-07-25-agent-interrupt-resume-and-im-adapter.md
+++ b/docs/vibe/2026-07-25-agent-interrupt-resume-and-im-adapter.md
@@ -1,0 +1,602 @@
+# Agent Interrupt / Resume 与纯文本 IM 接入方案（讨论稿）
+
+> 日期：2026-07-25
+>
+> 状态：待讨论，不代表最终接口承诺
+>
+> 关联议题：[GitHub Issue #837：Feat: 关于集成 IM](https://github.com/xerrors/Yuxi/issues/837)
+
+## 1. 背景
+
+`feat/cli-chat-debug` 已经用 `yuxi chat` 验证了外部客户端可以创建 Agent Call、订阅 Run SSE 并流式展示结果。但当 Agent 触发工具审批或 `ask_user_question` 时，当前外部调用链会暴露一个边界缺口：
+
+1. Run worker 能识别并发布 `ask_user_question_required`、`human_approval_required`、`interrupted` 事件；
+2. Web 前端能从事件中的 `questions`、`approval`、`interrupt_info` 渲染交互，并调用内部 Agent Run 接口创建 resume run；
+3. Agent Call 对外响应目前只返回 `status`、`output`、`error` 等结果，没有完整、稳定的 interrupt 对象；
+4. Agent Call 也没有同一命名空间下的 resume 接口，外部客户端必须了解内部 `/api/agent/runs` 的 `resume` 与 `created_by_run_id` 约定；
+5. 因此 CLI 把 `interrupted` 当作运行结束展示后，用户再输入“运行”，这条文本会被当作新的普通消息，而不是对上一个 interrupt 的决议，后端会拒绝继续执行。
+
+这不是单纯的 CLI 渲染问题，而是对外 Agent 生命周期尚未完整覆盖 `running -> interrupted -> resumed -> terminal`。
+
+## 2. 本方案要解决什么
+
+本方案分成两条能力线，底层共享同一个 interrupt 模型。
+
+### 2.1 富客户端
+
+适用于 CLI、Web、SDK 或其他能解析结构化事件的客户端：
+
+- 接收结构化 interrupt；
+- 根据 interrupt 类型渲染审批或问题；
+- 将结构化决议提交给公开 resume 接口；
+- 继续订阅新 run 的流式事件。
+
+第一阶段只要求 CLI 能完成该闭环，不要求先实现 IM。
+
+### 2.2 纯文本 IM
+
+适用于微信等只能收发普通文本、无法依赖按钮或复杂回调的渠道：
+
+- 所有入站消息进入统一的渠道消息入口；
+- 在消息进入普通 Agent turn 之前解析控制命令；
+- `/approve`、`/reject`、`/answer`、`/cancel` 等命令解析为结构化 interrupt 决议；
+- 只有确认不是控制命令或待回答问题的回复后，才把消息作为普通用户消息分发给 Agent。
+
+本阶段先定义机制，不讨论各 IM 的最终卡片、按钮和视觉渲染。
+
+### 2.3 非目标
+
+- 本文不选定首个正式支持的 IM 平台；
+- 不在当前 CLI 分支修改 backend；
+- 不要求所有渠道使用相同的按钮或卡片；
+- 不把 LangGraph 内部 `Command(resume=...)` 结构直接暴露为长期公共协议；
+- 不在第一阶段实现跨多个会话的统一人工审批工作台。
+
+## 3. 外部项目调研
+
+调研基于 2026-07-25 获取的源码快照，而非仅依赖产品文档或二手描述。
+
+### 3.1 Hermes Agent
+
+调研版本：[`NousResearch/hermes-agent@8f8b66d`](https://github.com/NousResearch/hermes-agent/tree/8f8b66d8ac6ed5172daa213b615037cae0ed92f9)
+
+#### 3.1.1 审批是会话内的阻塞队列
+
+Hermes 的 [`tools/approval.py`](https://github.com/NousResearch/hermes-agent/blob/8f8b66d8ac6ed5172daa213b615037cae0ed92f9/tools/approval.py) 使用 `session_key -> approval queue` 保存待审批项。每个待审批项有独立的 `threading.Event`，Agent 工作者阻塞等待决议；`/approve` 默认按 FIFO 解除最早一项，`/approve all` 才批量解除。
+
+值得借鉴的点：
+
+- 待审批状态绑定会话，而不是绑定某个临时 UI；
+- 等待有超时，超时不是默许；
+- `/stop` 等中断会解除等待并按拒绝处理，避免工作线程永远挂起；
+- 多个并行子任务产生审批时有明确的 FIFO / all 语义。
+
+需要谨慎的点：仅以 FIFO 省略审批 ID 对单 Agent、本地进程较方便，但对分布式服务、群聊和跨设备操作不够明确。
+
+#### 3.1.2 文本回复必须先经过等待状态解析
+
+Hermes 的 [`gateway/run.py`](https://github.com/NousResearch/hermes-agent/blob/8f8b66d8ac6ed5172daa213b615037cae0ed92f9/gateway/run.py) 在 Agent 已运行时优先检查 `has_blocking_approval(session_key)`。只有存在待审批时，裸文本 `yes`、`approve`、`no` 等才会被映射为审批决议，否则仍是普通对话文本。代码注释直接说明了原因：若把回复排到普通 follow-up 队列，当前 run 又在等待审批，两者会形成死锁，直到审批超时。
+
+这是纯文本渠道最重要的路由原则：
+
+```text
+入站消息
+  -> 身份与会话解析
+  -> 控制命令 / 待回答状态解析
+  -> resolve interrupt（命中时到此结束）
+  -> busy turn 的 steer / queue / interrupt 策略
+  -> 新普通 turn
+```
+
+#### 3.1.3 问题既支持按钮，也支持下一条文本
+
+Hermes 的 [`tools/clarify_gateway.py`](https://github.com/NousResearch/hermes-agent/blob/8f8b66d8ac6ed5172daa213b615037cae0ed92f9/tools/clarify_gateway.py) 为问题生成 `clarify_id`，同时维护 `clarify_id -> entry` 和 `session_key -> FIFO ids` 两个索引。富客户端按钮按 ID resolve；无按钮的渠道把同一会话的下一条非命令文本解释为回答。选择题可以输入序号或完整选项，自由文本问题接收普通文本。
+
+[`gateway/platforms/base.py`](https://github.com/NousResearch/hermes-agent/blob/8f8b66d8ac6ed5172daa213b615037cae0ed92f9/gateway/platforms/base.py) 定义了统一 `send_clarify` 降级：支持按钮的平台覆盖渲染，不支持的平台发送编号列表。Slash command 会绕过问题回答拦截，因此 `/stop` 等控制命令仍可执行。
+
+#### 3.1.4 渠道只负责表现，决议回到统一机制
+
+Hermes 的平台适配器优先尝试按钮审批，不支持时发送 `/approve`、`/deny` 文本说明。适配器最终调用同一个 resolver，而不是各自实现 Agent 恢复逻辑。例如 WhatsApp Cloud 的按钮 payload 携带 approval ID，文本渠道则使用命令。
+
+结论：Yuxi 的渠道插件也应只负责身份归一、消息收发和能力声明；interrupt 状态、授权、幂等与 resume 必须由核心服务统一管理。
+
+### 3.2 OpenClaw
+
+调研版本：[`openclaw/openclaw@d4a90c7`](https://github.com/openclaw/openclaw/tree/d4a90c7bbb69b78990582a3b8952ff99f1812fa3)
+
+#### 3.2.1 问题是独立的一等协议对象
+
+OpenClaw 的 [`packages/gateway-protocol/src/schema/questions.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/packages/gateway-protocol/src/schema/questions.ts) 定义了完整问题协议：
+
+- 稳定 `id`；
+- `agentId`、`sessionKey`；
+- `createdAtMs`、`expiresAtMs`；
+- `pending / answered / cancelled / expired` 状态；
+- `question.request / waitAnswer / resolve / get / list`；
+- `question.requested / question.resolved` 广播事件；
+- 回答者 `resolvedBy`。
+
+[`src/gateway/question-manager.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/src/gateway/question-manager.ts) 保证一次性状态转换、答案校验、超时和短期 terminal record 保留。重复 resolve 会明确返回 already-terminal，而不是重复执行。
+
+相比只在 SSE chunk 中附加临时字段，这种模型更适合作为 Yuxi 对外协议，因为客户端断线重连后仍可按 ID 查询状态并恢复 UI。
+
+#### 3.2.2 审批命令显式携带 ID 和决策
+
+OpenClaw 的 [`commands-approve.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/src/auto-reply/reply/commands-approve.ts) 使用：
+
+```text
+/approve <id> allow-once
+/approve <id> allow-always
+/approve <id> deny
+```
+
+处理流程同时校验：
+
+- 命令格式和决策枚举；
+- 当前渠道、账号与发送者是否有审批权；
+- Gateway client 是否有 `operator.approvals` / `operator.admin` scope；
+- ID 属于 exec approval 还是 plugin approval；
+- 请求是否存在或已经过期。
+
+[`exec-approval-reply.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/src/infra/exec-approval-reply.ts) 和相关提示允许使用短 ID，但如果短 ID 有歧义，要求使用完整 ID。这比“永远处理最旧一项”更适合公开系统。
+
+#### 3.2.3 `ask_user` 与普通消息抢占有明确边界
+
+OpenClaw 的 [`gateway-question.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/src/agents/harness/gateway-question.ts) 规定同一 `sessionKey` 最多注册一个待回答问题，并在普通 steering 前调用 `claimPendingAgentQuestionAnswer`。成功 claim 后该消息只作为问题答案，不再作为新的 Agent turn；注册失败或问题已 terminal 时才回落到普通消息路径。
+
+这同时解决两个问题：
+
+- 回答不会被重复记录成一次回答和一次新对话；
+- 问题注册与回答并发时，可以先缓冲答案，待 Gateway 注册提交后再 resolve。
+
+OpenClaw 还把问题按钮解析为统一的 `question.resolve`，并限制按钮解析只适用于单个、非 multi-select、非 secret 的问题，复杂问题留给更完整的交互面。
+
+#### 3.2.4 渲染和状态是分离的
+
+[`question-channel-runtime-internal.ts`](https://github.com/openclaw/openclaw/blob/d4a90c7bbb69b78990582a3b8952ff99f1812fa3/src/infra/question-channel-runtime-internal.ts) 记录一个问题可能投递到多个渠道 UI；问题 terminal 后，各投递面分别更新为 Answered / Cancelled / Expired。自由文本不会被回显到公共卡片，避免泄露秘密、mentions 或渠道 markup。
+
+结论：同一 interrupt 可以有多个表现面，但只能有一个核心状态与一次有效决议。
+
+### 3.3 OpenOcta（补充参考）
+
+调研版本：[`openocta/openocta@c4c5bd3`](https://github.com/openocta/openocta/tree/c4c5bd3e839707cb3b844c051f21dc36ced09eb8)
+
+OpenOcta 的 [`src/pkg/security/approval.go`](https://github.com/openocta/openocta/blob/c4c5bd3e839707cb3b844c051f21dc36ced09eb8/src/pkg/security/approval.go) 使用带 `id`、`session_id`、`pending / approved / denied`、审批人、原因、时间和过期时间的持久化 ApprovalQueue。执行方通过 `Wait(ctx, id)` 等待，context 取消会解除等待；session whitelist 也有 TTL。
+
+它进一步说明：审批记录应是可持久化、可审计的领域对象，不能只存在于某个 WebSocket 连接或 CLI 进程内。不过 Yuxi 不应直接照搬 session whitelist；是否支持“本会话始终允许”需要独立安全评审。
+
+## 4. 对 Yuxi 当前边界的判断
+
+Yuxi 已经具备大部分运行时基础：
+
+- `run_worker` 能把 Agent chunk 归一为 `interrupt` 事件；
+- interrupt chunk 已携带问题或审批所需的业务数据；
+- 内部 Agent Run 创建接口能校验 resume payload；
+- resume run 通过 `created_by_run_id` 建立父子关系；
+- 服务端已有 `resume_superseded` 检查，避免恢复一个已被后续 run 超越的中断；
+- Web 已经验证“解析 interrupt -> 收集用户决议 -> 创建 resume run -> 继续 SSE”的完整链路。
+
+缺少的是公开协议层，而不是 LangGraph 执行层：
+
+1. Agent Call 响应没有规范化 `interrupt`；
+2. Agent Call 没有原生 resume URL / endpoint；
+3. 外部客户端无法仅凭公开 Agent Call 文档恢复运行；
+4. 纯文本入站消息没有统一的控制命令解析与 pending interrupt 路由；
+5. interrupt 目前主要依附 run event chunk，缺少稳定 ID、独立状态、过期与审计表达。
+
+## 5. 推荐的统一领域模型
+
+建议把“Run 已中断”和“等待用户处理的 Interrupt”区分开：Run 是一次执行，Interrupt 是该执行产生、等待外部决议的对象。
+
+```json
+{
+  "interrupt_id": "int_01...",
+  "run_id": "run_01...",
+  "thread_id": "thread_01...",
+  "agent_slug": "...",
+  "kind": "tool_approval",
+  "status": "pending",
+  "version": 1,
+  "created_at": "2026-07-25T10:00:00Z",
+  "expires_at": "2026-07-25T10:15:00Z",
+  "allowed_actions": ["approve", "reject"],
+  "payload": {
+    "action_requests": [],
+    "review_configs": []
+  },
+  "resolution": null,
+  "resolved_at": null,
+  "resolved_by": null
+}
+```
+
+### 5.1 类型
+
+第一阶段只定义两类：
+
+- `tool_approval`：工具调用审批；
+- `question`：结构化或自由文本问题。
+
+`interrupted` 如果只是用户取消、服务器停止等终态，不一定创建可 resume 的 Interrupt。只有确实存在 `allowed_actions` 的中断才返回 `status=pending` 的 Interrupt，避免客户端误以为所有 interrupted run 都能继续。
+
+### 5.2 状态
+
+建议状态为：
+
+```text
+pending -> resolved
+pending -> cancelled
+pending -> expired
+pending -> superseded
+```
+
+终态不可再次修改。生命周期状态与业务决议分开表达：`resolved` 表示 `approve`、`reject` 或 `answer` 决议已被接受，并成功创建唯一的子 resume run；具体决议保存在 `resolution.action`，而不是另设容易和 HTTP 请求拒绝混淆的 `rejected` 状态。`cancelled` 表示明确终止、不再创建 resume run。
+
+### 5.3 决议载荷
+
+公共协议不直接暴露 LangGraph 内部字段。建议使用稳定的外部表达，由服务层转换为现有 `resume.decisions`：
+
+审批：
+
+```json
+{
+  "interrupt_id": "int_01...",
+  "action": "approve",
+  "decisions": [
+    {"action_request_id": "...", "decision": "approve"}
+  ],
+  "request_id": "client-generated-id"
+}
+```
+
+提问：
+
+```json
+{
+  "interrupt_id": "int_01...",
+  "action": "answer",
+  "answers": {
+    "question_1": ["选项 A"],
+    "question_2": ["自由文本"]
+  },
+  "request_id": "client-generated-id"
+}
+```
+
+## 6. 能力线一：富客户端公开接口
+
+### 6.1 最小第一阶段
+
+建议在 Agent Call 命名空间内补齐闭环：
+
+```http
+POST /api/agent-invocation/agent-call/runs
+GET  /api/agent-invocation/agent-call/runs/{run_id}
+GET  /api/agent-invocation/agent-call/runs/{run_id}/events
+POST /api/agent-invocation/agent-call/runs/{run_id}/resume
+POST /api/agent-invocation/agent-call/runs/{run_id}/cancel
+```
+
+考虑最小改动，`GET result` 与 Agent Call 专用 SSE 可以后续规范化；第一步至少必须做到：
+
+1. 现有 Agent Call 结果在 interrupted 时返回完整 `interrupt`；
+2. 新增 Agent Call 原生 resume endpoint；
+3. 创建 run 的响应给出可发现链接，而不是让客户端拼内部路径。
+
+建议响应：
+
+```json
+{
+  "run_id": "...",
+  "thread_id": "...",
+  "status": "interrupted",
+  "interrupt": {},
+  "links": {
+    "self": "/api/agent-invocation/agent-call/runs/...",
+    "events": "/api/agent-invocation/agent-call/runs/.../events",
+    "resume": "/api/agent-invocation/agent-call/runs/.../resume",
+    "cancel": "/api/agent-invocation/agent-call/runs/.../cancel"
+  }
+}
+```
+
+### 6.2 CLI 行为
+
+`yuxi chat` 收到 interrupt 后：
+
+1. 保持原 assistant 流式文本；
+2. 将当前消息标记为“等待操作”，不能显示成普通成功结束；
+3. `tool_approval` 渲染批准 / 拒绝；
+4. `question` 渲染选项或输入框；
+5. 调用公开 resume endpoint；
+6. 使用返回的新 `run_id` 继续订阅 SSE，复用原 `thread_id`；
+7. 页面刷新后按 thread/run 查询 pending interrupt 并恢复交互。
+
+CLI 页面只是渲染器，不自行拼 LangGraph resume 数据，也不从普通聊天文本猜审批决议。
+
+## 7. 能力线二：纯文本 IM 统一入口
+
+### 7.1 统一入站信封
+
+外部平台 webhook 与 adapter 到核心服务的 ingestion 必须是两个信任层：
+
+```text
+平台 webhook
+  -> 渠道专用接收端（平台验签、时间窗、message_id 去重）
+  -> 统一内部 ingestion（adapter 服务身份认证、binding 鉴权）
+  -> 核心消息路由
+```
+
+建议渠道适配器把各平台 webhook 归一后送入同一内部入口，例如：
+
+```http
+POST /internal/agent-invocation/channel/messages
+```
+
+```json
+{
+  "adapter_binding_id": "binding_01...",
+  "channel": "wechat",
+  "account_id": "official-account-a",
+  "message_id": "provider-message-id",
+  "chat_id": "chat-id",
+  "thread_id": null,
+  "sender": {"id": "provider-user-id", "display_name": "..."},
+  "message": {"type": "text", "text": "/approve int_01..."},
+  "timestamp": "...",
+  "signature_context": {}
+}
+```
+
+这是适配器到核心服务的内部标准，不是可匿名访问的公共 webhook，也不建议让每个渠道直接调用 Agent resume。Adapter 负责平台验签、去重、平台 ID 提取与发送；核心服务负责会话映射、权限、命令和 Agent 生命周期。
+
+Adapter 到 ingestion 必须使用 mTLS、请求 HMAC 或 OAuth service principal 等服务身份认证。核心服务根据认证主体与 `adapter_binding_id` 在服务端派生允许的 `tenant_id / channel / account_id`，并拒绝信封声明与 binding 不一致的请求；不得信任调用方自行提交的 tenant、channel、account、sender 权限或 `signature_context`。`signature_context` 若仅用于审计，只能携带非敏感验签结果摘要，不能作为核心鉴权事实，也不能包含原始签名密钥。
+
+### 7.2 路由键
+
+仅用 `user_id` 或 `chat_id` 都不够。建议基础 conversation key 为：
+
+```text
+(tenant_id, channel, account_id, chat_id, provider_thread_id?)
+```
+
+并额外记录发送者：
+
+```text
+actor = (channel, account_id, sender_id)
+```
+
+conversation key 映射到 Yuxi `thread_id`。群聊中 pending interrupt 属于 conversation，但能否 resolve 由 actor authorization 单独判断，不能因为同处一个群就自动有审批权。
+
+### 7.3 命令语法
+
+推荐最小命令集：
+
+```text
+/pending
+/approve <interrupt_id>
+/reject <interrupt_id> [reason]
+/answer <interrupt_id> <text>
+/cancel <run_id>
+/help
+```
+
+选择题可增加可机器解析的形式：
+
+```text
+/answer <interrupt_id> <question_id>=2
+/answer <interrupt_id> <question_id>="自定义答案"
+```
+
+如果一个 interrupt 只包含一个问题，可允许：
+
+```text
+/answer <interrupt_id> 2
+```
+
+不建议第一版加入 `/approve all`，因为批量批准扩大误操作半径。若未来加入，必须在命令中显示作用域和数量，并单独做安全评审。
+
+### 7.4 是否接受“运行”“是”“同意”等自然文本
+
+建议默认规则：
+
+- 工具审批：不接受普通自然文本，必须是带 ID 的 slash command 或可信按钮回调；
+- 问题回答：优先 `/answer <id> ...`；同一 conversation 恰好只有一个 pending question、发送者有权回答且消息不是命令时，可以把下一条文本 claim 为回答；
+- 群聊、多个 pending interrupt、多个问题或安全敏感问题：禁止隐式 claim，必须带 ID；
+- 自然语言别名可作为渠道级 opt-in，且只在“唯一 pending + 私聊 + 同一 actor”时启用。
+
+原因：Hermes 的裸 `yes` 依赖严格的会话内唯一等待状态，适合单进程交互；公开服务可能存在多 run、多设备和群聊。OpenClaw 的显式 ID 更稳妥。问题自由文本又天然需要接收普通消息，因此可以在无歧义条件下提供受限便利。
+
+### 7.5 入口解析顺序
+
+```text
+1. 验证 adapter 服务身份与 binding，并确认平台验签和时间窗校验已由受信 adapter 完成；核心按 provider message_id 再次去重
+2. 从 binding 派生 tenant / channel account，再解析 chat / thread / actor
+3. 建立或读取 Yuxi thread 映射
+4. 识别 slash command
+5. 查询该 conversation 的 pending interrupts
+6. 命令命中：鉴权、resolve、返回确认，不创建普通 Agent turn
+7. 非命令且满足唯一 pending question 规则：claim 为 answer，不创建普通 Agent turn
+8. 否则按 busy policy 执行 steer / queue / reject / new turn
+```
+
+关键不变量：一条入站消息只能被消费一次。它要么是 interrupt 决议，要么是普通 Agent 消息，不能两者都是。
+
+## 8. Resume、幂等和并发
+
+### 8.1 一次 interrupt 只产生一个有效 resume run
+
+服务端应在同一事务或等效原子操作中完成：
+
+1. 校验 interrupt 为 `pending`；
+2. 校验它仍是 thread 最新可恢复中断；
+3. 校验 actor 有权执行 action；
+4. 规范化 action / decisions / answers，并计算包含 actor、tenant 与授权 scope 的 payload hash；
+5. 用 `interrupt_id + request_id` 查找幂等记录并核对 payload hash 与 actor；
+6. 创建唯一 child resume run；
+7. 将 interrupt 标记为 terminal，并记录 `resolution` 与 `resumed_run_id`。
+
+两个客户端同时批准时，只允许一个成功创建 child run。另一个请求：
+
+- 同 request ID、同 actor、同授权范围且 canonical payload 相同：返回第一次创建的同一个 run；
+- 同 request ID 但 action、答案、actor 或授权范围不同：返回 `409 idempotency_key_conflict`，绝不能静默复用旧决议；
+- 不同 request ID：返回 `409 interrupt_already_resolved`；
+- 已被后续 turn 超越：返回 `409 interrupt_superseded`；
+- 已过期：返回 `410 interrupt_expired`。
+
+### 8.2 不把“收到决议”误认为“恢复成功”
+
+如果创建 resume run 失败，interrupt 不应被永久标成 resolved。可以使用事务、outbox，或先记录 resolving lease 再提交；最终必须可重试且不会重复创建 run。
+
+### 8.3 断线重连
+
+客户端不能只依赖实时 SSE。至少需要通过 run 或 thread 查询当前 pending interrupt。SSE 用于低延迟通知，查询接口是恢复事实来源。
+
+## 9. 安全与审计
+
+### 9.1 授权
+
+- Agent Call：沿用调用 API Key 的用户 / tenant 权限，并校验 run 归属；
+- IM：渠道验签只证明消息来自平台，不等于发送者有审批权；
+- 私聊可绑定 Yuxi 用户；群聊需要 owner / approver allowlist 或明确角色映射；
+- 回答普通问题和批准危险工具可以使用不同权限。
+
+### 9.2 防重放
+
+- 渠道 `message_id` 去重；
+- webhook timestamp / nonce 时间窗；
+- interrupt terminal 后拒绝再次 resolve；
+- request ID 幂等；
+- 按钮 callback 必须携带不可猜测或签名过的 interrupt reference。
+
+### 9.3 最小披露
+
+- 审批提示展示执行所需的最小命令与影响，凭据先脱敏；
+- 群聊中不回显自由文本答案；
+- adapter 日志不记录 API Key、原始签名密钥或敏感回答；
+- `resolved_by` 记录稳定 actor ID，不只记录昵称。
+
+### 9.4 审计字段
+
+至少记录：
+
+- interrupt / run / thread；
+- channel / account / chat / actor；
+- 原始 action 与标准化 decision；
+- request ID、provider message ID；
+- created / resolved / expired 时间；
+- 是否来自按钮、slash command、富客户端或隐式 answer claim；
+- resume child run ID；
+- 拒绝或失败原因。
+
+## 10. 推荐实施阶段
+
+### Phase 1：公开 Resume + CLI 闭环
+
+- Agent Call interrupted 响应返回结构化 interrupt；
+- 新增 Agent Call 原生 resume endpoint；
+- 提供 pending interrupt 查询能力；
+- `yuxi chat` 渲染审批 / 问题并继续流式输出；
+- 覆盖刷新恢复、重复点击、超时、superseded 与断线重连测试。
+
+这是当前最优先工作，能先证明公共协议，不依赖任何 IM。
+
+### Phase 2：文本命令与统一消息路由
+
+- 定义 channel message envelope 与 conversation mapping；
+- 实现独立、可测试的 slash command parser；
+- 命令解析发生在普通 Agent dispatch 前；
+- 实现 `/pending`、`/approve`、`/reject`、`/answer`、`/cancel`；
+- 实现唯一 pending question 的受限文本 claim；
+- 完成 actor authorization、幂等和审计。
+
+### Phase 3：首个 IM Adapter
+
+- 选择一个具备稳定 webhook 与测试环境的渠道；
+- 实现签名验证、入站去重、出站发送、错误重试；
+- 富能力渠道用按钮 / 卡片，文本能力缺失时自动降级为 slash command；
+- adapter 不包含 Agent resume 业务逻辑。
+
+### Phase 4：多渠道与统一审批面
+
+- 增加飞书、钉钉、微信等适配器；
+- 支持一个 interrupt 投递到多个授权表现面；
+- 任一表现面成功 resolve 后，其他表现面更新 terminal 状态；
+- 评估是否需要跨会话审批箱和代理审批人。
+
+## 11. 测试与验收建议
+
+### 11.1 公共 API
+
+- question / approval 两类 interrupt schema 稳定；
+- interrupted run 查询能恢复完整 payload；
+- resume 成功产生 child run 并继续 SSE；
+- 重复同 request ID 返回同一 child run；
+- 并发不同决议只有一个成功；
+- expired / cancelled / superseded 返回明确错误；
+- 非 run 所属用户不可查询或 resolve。
+
+### 11.2 CLI
+
+- 流式文本后出现审批 UI，不显示为普通完成；
+- approve / reject 均能继续到明确 terminal；
+- 选择题、自由文本、多个问题可提交；
+- 刷新后恢复 pending UI；
+- SSE EOF 且无 terminal event 不误报成功；
+- API Key 不进入浏览器 HTML / JS / console。
+
+### 11.3 纯文本入口
+
+- `/approve <id>` 不创建普通 Agent turn；
+- 普通“是”在没有 pending 时仍是普通消息；
+- 多 pending 时省略 ID 必须拒绝并返回 `/pending` 提示；
+- 唯一 question 的文本回答只消费一次；
+- slash command 在 question pending 时仍优先执行；
+- 群聊未授权成员不能批准；
+- provider 重放同一 message ID 不重复恢复；
+- 两个渠道同时处理同一 interrupt 只有一个成功；
+- 相同 request ID 改变 approve / reject、答案或 actor 时返回 idempotency conflict；
+- 未认证 adapter、binding 越权和信封身份与 binding 不一致时均被拒绝。
+
+### 11.4 Adapter contract
+
+- 验签失败不进入核心路由；
+- 渠道限流或临时失败进入可观测重试；
+- 不支持按钮时生成可直接复制的文本命令；
+- terminal 后按钮更新或文本回复清楚说明已处理 / 已过期。
+
+## 12. 需要讨论并拍板的问题
+
+1. Interrupt 是否第一版就落独立表，还是先从 run terminal chunk 派生并在后续迁移？推荐独立持久化对象，避免刷新和多端解析依赖事件细节。
+2. Agent Call 是否趁此改成标准 REST `GET /runs/{id}`，还是先保持现有 `POST /runs/result` 兼容并只新增 resume？推荐先兼容新增，之后版本化整理。
+3. `question` 是否默认允许唯一 pending 时把下一条普通文本 claim 为回答？推荐私聊允许、群聊禁用，并支持渠道配置覆盖。
+4. 第一版是否支持 `allow-always` / “本会话始终允许”？推荐不支持，只做单次 approve / reject，待权限和 allowlist 模型成熟后再评估。
+5. 多个 action request 是否允许整组批准，还是要求逐项 decision？推荐协议支持逐项，UI 可以提供“全部批准”但必须提交显式列表。
+6. 首个 IM 应选哪个？应根据 webhook 可测试性、机器人权限、按钮能力、群聊身份稳定性和国内部署约束另开选型讨论。
+7. 渠道账号与 Yuxi 用户如何绑定？需要决定管理员静态映射、一次性 pairing code、OAuth 或企业组织目录中的一种或组合。
+8. `/cancel <run_id>` 是只取消仍在执行的 run，还是也能取消该 run 产生的 pending Interrupt？推荐拆成明确语义：`/cancel <run_id>` 只取消 active run，`/cancel-interrupt <interrupt_id>` 才终止等待且不创建 resume run，避免对已 terminal 的 interrupted run 产生歧义。
+
+## 13. 推荐结论
+
+建议先批准机制方向，不在本议题内直接批准具体 backend 实现：
+
+1. 将 Interrupt 作为带稳定 ID、状态、过期与审计的一等对象；
+2. Agent Call 补齐结构化 interrupt、公开 resume 与可恢复查询；
+3. CLI 先完成富客户端 resume 验证；
+4. 纯文本消息统一进入渠道入口，控制命令和 pending question claim 必须先于普通消息分发；
+5. 审批默认使用显式 interrupt ID，问题仅在严格无歧义时允许下一条文本隐式回答；
+6. Adapter 只做平台能力适配，不复制 interrupt / resume 核心逻辑。
+
+## 14. Checklist
+
+- [x] 核对 Yuxi 当前 interrupt / resume 内部链路
+- [x] 调研 Hermes Agent 的审批、提问、文本降级和会话路由
+- [x] 调研 OpenClaw 的稳定 ID、问题 RPC、审批命令与授权
+- [x] 补充 OpenOcta 持久化审批队列参考
+- [x] 给出富客户端与纯文本 IM 两条能力线
+- [x] 给出状态模型、命令语法、消歧、幂等、安全与测试建议
+- [ ] 讨论并确认公共 Interrupt schema
+- [ ] 讨论并确认 Agent Call resume API
+- [ ] 讨论并确认文本回答的隐式 claim 规则
+- [ ] 确认首个 IM 与身份绑定方案
+- [ ] 经方案评审后拆分实现任务

--- a/packages/yuxi-cli/README.md
+++ b/packages/yuxi-cli/README.md
@@ -9,5 +9,6 @@ First-stage scope:
 - API Key import through `--api-key`
 - `whoami`, `status`, and `logout`
 - server discovery and compatibility check for Yuxi `>=0.7.1`
+- `yuxi chat` for a temporary local browser chat with streamed Agent output
 - `yuxi kb upload` for knowledge base file uploads
 - `yuxi agent eval` for running existing Langfuse dataset experiments with a logged-in remote

--- a/packages/yuxi-cli/pyproject.toml
+++ b/packages/yuxi-cli/pyproject.toml
@@ -41,6 +41,9 @@ yuxi = "yuxi_cli.main:app"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+yuxi_cli = ["chat.html"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/packages/yuxi-cli/src/yuxi_cli/chat.html
+++ b/packages/yuxi-cli/src/yuxi_cli/chat.html
@@ -1,0 +1,324 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Yuxi Chat</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --canvas: #f7f6f3;
+        --surface: #ffffff;
+        --text: #20201e;
+        --muted: #787774;
+        --border: #e4e3df;
+        --soft: #efeee9;
+        --error: #9f2f2d;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: var(--canvas);
+        color: var(--text);
+        font-family: "SF Pro Display", "Helvetica Neue", Arial, sans-serif;
+      }
+
+      .shell {
+        width: min(860px, calc(100% - 32px));
+        min-height: 100vh;
+        margin: 0 auto;
+        padding: 36px 0 24px;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        gap: 20px;
+      }
+
+      header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      h1 {
+        margin: 0 0 5px;
+        font-family: "Newsreader", Georgia, serif;
+        font-size: clamp(30px, 5vw, 44px);
+        line-height: 1;
+        letter-spacing: -0.035em;
+        font-weight: 500;
+      }
+
+      .meta {
+        margin: 0;
+        color: var(--muted);
+        font: 12px/1.5 "SF Mono", Menlo, monospace;
+      }
+
+      button {
+        border: 0;
+        border-radius: 5px;
+        background: #20201e;
+        color: #fff;
+        padding: 10px 15px;
+        font: 600 13px/1 "SF Pro Display", "Helvetica Neue", sans-serif;
+        cursor: pointer;
+      }
+
+      button:hover { background: #3a3936; }
+      button:active { transform: scale(0.98); }
+      button:disabled { cursor: not-allowed; opacity: 0.45; }
+
+      .secondary {
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--border);
+      }
+
+      .secondary:hover { background: var(--soft); }
+
+      #messages {
+        min-height: 360px;
+        padding: 26px;
+        overflow-y: auto;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+      }
+
+      .empty {
+        height: 100%;
+        min-height: 306px;
+        display: grid;
+        place-items: center;
+        color: var(--muted);
+        text-align: center;
+        line-height: 1.6;
+      }
+
+      .message {
+        max-width: 78%;
+        margin-bottom: 18px;
+        padding: 13px 15px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        animation: appear 180ms ease-out both;
+      }
+
+      .message.user {
+        margin-left: auto;
+        background: #f3f2ee;
+      }
+
+      .message.assistant { background: #fff; }
+      .message.error { color: var(--error); background: #fdebec; }
+
+      .label {
+        display: block;
+        margin-bottom: 7px;
+        color: var(--muted);
+        font: 10px/1 "SF Mono", Menlo, monospace;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .content {
+        margin: 0;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        font: 15px/1.65 "SF Pro Display", "Helvetica Neue", sans-serif;
+      }
+
+      form {
+        padding: 14px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+      }
+
+      textarea {
+        display: block;
+        width: 100%;
+        min-height: 86px;
+        resize: vertical;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: var(--text);
+        font: 15px/1.55 "SF Pro Display", "Helvetica Neue", sans-serif;
+      }
+
+      textarea::placeholder { color: #aaa8a2; }
+
+      .composer-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding-top: 10px;
+        border-top: 1px solid var(--border);
+      }
+
+      #status {
+        color: var(--muted);
+        font: 11px/1.4 "SF Mono", Menlo, monospace;
+      }
+
+      @keyframes appear {
+        from { opacity: 0; transform: translateY(6px); }
+        to { opacity: 1; transform: translateY(0); }
+      }
+
+      @media (max-width: 620px) {
+        .shell { width: min(100% - 20px, 860px); padding-top: 22px; }
+        #messages { padding: 16px; }
+        .message { max-width: 92%; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .message { animation: none; }
+        button:active { transform: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <div>
+          <h1>Yuxi Chat</h1>
+          <p class="meta">Agent <span id="agent"></span></p>
+        </div>
+        <button id="new-chat" class="secondary" type="button">新对话</button>
+      </header>
+
+      <section id="messages" aria-live="polite">
+        <div class="empty">本地调试会话<br />输入消息开始测试</div>
+      </section>
+
+      <form id="composer">
+        <textarea id="input" placeholder="输入消息，Enter 发送，Shift + Enter 换行" autofocus></textarea>
+        <div class="composer-row">
+          <span id="status">就绪</span>
+          <button id="send" type="submit">发送</button>
+        </div>
+      </form>
+    </main>
+
+    <script>
+      const sessionToken = __SESSION_TOKEN__;
+      const agentSlug = __AGENT_SLUG__;
+      const messages = document.querySelector("#messages");
+      const composer = document.querySelector("#composer");
+      const input = document.querySelector("#input");
+      const send = document.querySelector("#send");
+      const status = document.querySelector("#status");
+      document.querySelector("#agent").textContent = agentSlug;
+
+      let threadId = null;
+      let running = false;
+
+      function addMessage(role, content = "") {
+        messages.querySelector(".empty")?.remove();
+        const item = document.createElement("article");
+        item.className = `message ${role}`;
+        const label = document.createElement("span");
+        label.className = "label";
+        label.textContent = role === "user" ? "You" : role === "error" ? "Error" : "Yuxi";
+        const text = document.createElement("pre");
+        text.className = "content";
+        text.textContent = content;
+        item.append(label, text);
+        messages.append(item);
+        messages.scrollTop = messages.scrollHeight;
+        return text;
+      }
+
+      function setRunning(value) {
+        running = value;
+        send.disabled = value;
+        input.disabled = value;
+        status.textContent = value ? "生成中" : "就绪";
+      }
+
+      async function readEvents(response, output) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let completed = false;
+
+        while (true) {
+          const { value, done } = await reader.read();
+          buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            const event = JSON.parse(line);
+            if (event.type === "meta") threadId = event.thread_id || threadId;
+            if (event.type === "delta") {
+              output.textContent += event.content;
+              messages.scrollTop = messages.scrollHeight;
+            }
+            if (event.type === "error") throw new Error(event.message);
+            if (event.type === "done") completed = event.status === "completed";
+          }
+          if (done) break;
+        }
+        if (!completed) throw new Error("回答流在完成前中断，请重试");
+      }
+
+      async function submitMessage() {
+        const message = input.value.trim();
+        if (!message || running) return;
+        input.value = "";
+        addMessage("user", message);
+        const output = addMessage("assistant");
+        setRunning(true);
+
+        try {
+          const response = await fetch("/api/chat", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Yuxi-Chat-Token": sessionToken
+            },
+            body: JSON.stringify({ message, thread_id: threadId })
+          });
+          if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.error || `请求失败：${response.status}`);
+          }
+          await readEvents(response, output);
+        } catch (error) {
+          output.closest(".message").remove();
+          addMessage("error", error.message || String(error));
+        } finally {
+          setRunning(false);
+          input.focus();
+        }
+      }
+
+      composer.addEventListener("submit", (event) => {
+        event.preventDefault();
+        submitMessage();
+      });
+
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          submitMessage();
+        }
+      });
+
+      document.querySelector("#new-chat").addEventListener("click", () => {
+        if (running) return;
+        threadId = null;
+        messages.innerHTML = '<div class="empty">本地调试会话<br />输入消息开始测试</div>';
+        input.focus();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/yuxi-cli/src/yuxi_cli/chat_web.py
+++ b/packages/yuxi-cli/src/yuxi_cli/chat_web.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import secrets
+import uuid
+import webbrowser
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.resources import files
+from typing import Any
+from urllib.parse import urlsplit
+
+from rich.console import Console
+
+from yuxi_cli.client import ClientError, YuxiClient
+from yuxi_cli.config import ConfigStore
+
+MAX_MESSAGE_BYTES = 32 * 1024
+
+
+class ChatWebError(Exception):
+    """CLI Web Chat 无法启动或处理请求。"""
+
+
+class ChatWebServer(ThreadingHTTPServer):
+    """仅监听本机并代理 Yuxi Agent 请求的临时 HTTP 服务。"""
+
+    daemon_threads = True
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        client: YuxiClient,
+        agent_slug: str,
+        session_token: str,
+    ):
+        super().__init__(address, ChatRequestHandler)
+        self.client = client
+        self.agent_slug = agent_slug
+        self.session_token = session_token
+
+    @property
+    def origin(self) -> str:
+        host, port = self.server_address[:2]
+        return f"http://{host}:{port}"
+
+
+class ChatRequestHandler(BaseHTTPRequestHandler):
+    """提供单页界面，并将聊天请求转换为浏览器可读的增量事件。"""
+
+    server: ChatWebServer
+
+    def do_GET(self) -> None:
+        if urlsplit(self.path).path != "/":
+            self.send_error(404)
+            return
+
+        template = files("yuxi_cli").joinpath("chat.html").read_text(encoding="utf-8")
+        page = template.replace(
+            "__SESSION_TOKEN__", json.dumps(self.server.session_token)
+        ).replace("__AGENT_SLUG__", json.dumps(self.server.agent_slug))
+        body = page.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'",
+        )
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        if urlsplit(self.path).path != "/api/chat":
+            self.send_error(404)
+            return
+        if not self._is_local_request():
+            self._send_json_error(403, "请求来源无效")
+            return
+        if not secrets.compare_digest(
+            self.headers.get("X-Yuxi-Chat-Token", ""), self.server.session_token
+        ):
+            self._send_json_error(403, "会话令牌无效")
+            return
+
+        try:
+            payload = self._read_payload()
+            message = str(payload.get("message") or "").strip()
+            if not message:
+                raise ChatWebError("消息不能为空")
+            thread_id = str(payload.get("thread_id") or "").strip() or None
+            run = self.server.client.create_agent_chat_run(
+                message=message,
+                agent_slug=self.server.agent_slug,
+                thread_id=thread_id,
+                request_id=str(uuid.uuid4()),
+            )
+            run_id = str(run.get("run_id") or "").strip()
+            if not run_id:
+                raise ChatWebError(str(run.get("error") or "远端未返回 run_id"))
+        except (ChatWebError, ClientError, json.JSONDecodeError) as exc:
+            self._send_json_error(400, str(exc))
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-ndjson; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Connection", "close")
+        self.end_headers()
+
+        try:
+            self._write_event(
+                {
+                    "type": "meta",
+                    "run_id": run_id,
+                    "thread_id": run.get("thread_id"),
+                }
+            )
+            for event in _browser_events(
+                self.server.client.stream_agent_run_events(run_id),
+                thread_id=str(run.get("thread_id") or "") or None,
+            ):
+                self._write_event(event)
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        except (ChatWebError, ClientError) as exc:
+            self._write_event({"type": "error", "message": str(exc)})
+
+    def _is_local_request(self) -> bool:
+        origin = self.headers.get("Origin")
+        return origin is None or origin == self.server.origin
+
+    def _read_payload(self) -> dict[str, Any]:
+        raw_length = self.headers.get("Content-Length")
+        if not raw_length:
+            raise ChatWebError("请求缺少 Content-Length")
+        try:
+            length = int(raw_length)
+        except ValueError as exc:
+            raise ChatWebError("Content-Length 无效") from exc
+        if length <= 0 or length > MAX_MESSAGE_BYTES:
+            raise ChatWebError("消息过长")
+
+        payload = json.loads(self.rfile.read(length))
+        if not isinstance(payload, dict):
+            raise ChatWebError("请求内容必须是 JSON 对象")
+        return payload
+
+    def _write_event(self, payload: dict[str, Any]) -> None:
+        self.wfile.write(
+            json.dumps(payload, ensure_ascii=False).encode("utf-8") + b"\n"
+        )
+        self.wfile.flush()
+
+    def _send_json_error(self, status: int, message: str) -> None:
+        body = json.dumps({"error": message}, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+
+def _browser_events(
+    events: Iterator[dict[str, str]],
+    *,
+    thread_id: str | None = None,
+) -> Iterator[dict[str, Any]]:
+    """把远端 Run SSE 压缩为页面需要的文本增量与终态。"""
+    saw_terminal = False
+
+    for event in events:
+        try:
+            data = json.loads(event.get("data") or "{}")
+        except json.JSONDecodeError as exc:
+            raise ChatWebError("远端返回了无效的流事件") from exc
+        if not isinstance(data, dict):
+            continue
+        if thread_id and data.get("thread_id") not in {None, thread_id}:
+            continue
+
+        event_type = event.get("event") or "message"
+        payload = data.get("payload") if isinstance(data.get("payload"), dict) else {}
+        chunks = (
+            payload.get("items")
+            if isinstance(payload.get("items"), list)
+            else [payload.get("chunk")]
+        )
+        for chunk in chunks:
+            if not isinstance(chunk, dict):
+                continue
+            stream_event = chunk.get("stream_event")
+            if (
+                isinstance(stream_event, dict)
+                and stream_event.get("type") == "message_delta"
+            ):
+                content = stream_event.get("content")
+                if isinstance(content, str) and content:
+                    yield {"type": "delta", "content": content}
+
+        if event_type == "error":
+            chunk = (
+                payload.get("chunk") if isinstance(payload.get("chunk"), dict) else {}
+            )
+            if chunk.get("retryable") is True or payload.get("retryable") is True:
+                continue
+            message = (
+                chunk.get("error_message")
+                or chunk.get("message")
+                or data.get("message")
+                or "运行失败"
+            )
+            yield {"type": "error", "message": str(message)}
+            return
+        elif event_type == "end":
+            saw_terminal = True
+            status = str(payload.get("status") or "completed")
+            if status != "completed":
+                yield {"type": "error", "message": f"运行结束：{status}"}
+            yield {"type": "done", "status": status}
+
+    if not saw_terminal:
+        raise ChatWebError("运行事件流在终态前断开，请重试")
+
+
+def run_web_chat(
+    store: ConfigStore,
+    remote_name: str | None,
+    agent_slug: str,
+    console: Console,
+    *,
+    no_open: bool = False,
+    open_browser: Callable[[str], bool] = webbrowser.open,
+) -> None:
+    """启动本地 Web Chat，直至用户按下 Ctrl+C。"""
+    remote = store.load().get_remote(remote_name)
+    if not remote.has_api_key:
+        raise ChatWebError("当前 remote 尚未登录，请先运行 yuxi login")
+
+    client = YuxiClient(remote)
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, agent_slug, secrets.token_urlsafe(24)
+    )
+    url = server.origin
+    console.print(f"Web Chat: {url}")
+    console.print("按 Ctrl+C 退出")
+    if not no_open:
+        open_browser(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        console.print("\nWeb Chat 已关闭")
+    finally:
+        server.server_close()
+        client.close()

--- a/packages/yuxi-cli/src/yuxi_cli/client.py
+++ b/packages/yuxi-cli/src/yuxi_cli/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -190,6 +191,57 @@ class YuxiClient:
         }
         return self._request("POST", "/agent-invocation/eval/runs", json=payload, timeout=timeout_seconds)
 
+    def create_agent_chat_run(
+        self,
+        *,
+        message: str,
+        agent_slug: str,
+        thread_id: str | None,
+        request_id: str,
+    ) -> dict:
+        """创建供 CLI Chat 使用的异步 Agent Run。"""
+        return self._request(
+            "POST",
+            "/agent-invocation/agent-call/runs",
+            json={
+                "agent_slug": agent_slug,
+                "messages": [{"role": "user", "content": message}],
+                "thread_id": thread_id,
+                "request_id": request_id,
+                "async_mode": True,
+                "queue_policy": "reject",
+            },
+        )
+
+    def stream_agent_run_events(self, run_id: str) -> Iterator[dict[str, str]]:
+        """读取 Agent Run SSE，并逐条返回解析后的事件。"""
+        headers = {}
+        if self.remote.api_key:
+            headers["Authorization"] = f"Bearer {self.remote.api_key}"
+        url = f"{self.remote.api_base_url}/agent/runs/{run_id}/events"
+
+        try:
+            with self.client.stream(
+                "GET",
+                url,
+                headers=headers,
+                params={"verbose": "false"},
+                timeout=None,
+            ) as response:
+                if response.status_code >= 400:
+                    response.read()
+                    error_code, error_message = _parse_http_error(response)
+                    raise ClientError(
+                        error_message,
+                        error_code=error_code,
+                        status_code=response.status_code,
+                    )
+                yield from _iter_sse_events(response.iter_lines())
+        except ClientError:
+            raise
+        except httpx.HTTPError as exc:
+            raise ClientError(f"运行事件流连接失败: {exc}") from exc
+
     def authorize_url(self, session: CLIAuthSession) -> str:
         return build_url(self.remote.url, session.authorize_path)
 
@@ -262,3 +314,34 @@ def _parse_http_error(response: httpx.Response) -> tuple[str | None, str]:
     if detail:
         return None, str(detail)
     return None, f"HTTP {response.status_code}"
+
+
+def _iter_sse_events(lines: Iterator[str]) -> Iterator[dict[str, str]]:
+    """解析 SSE 文本行，忽略 heartbeat，并保留 event、data 与 id。"""
+    event: dict[str, str] = {}
+    data_lines: list[str] = []
+
+    for line in lines:
+        if not line:
+            if data_lines:
+                event["data"] = "\n".join(data_lines)
+                yield event
+            event = {}
+            data_lines = []
+            continue
+        if line.startswith(":"):
+            continue
+
+        field, separator, value = line.partition(":")
+        if not separator:
+            value = ""
+        elif value.startswith(" "):
+            value = value[1:]
+        if field == "data":
+            data_lines.append(value)
+        elif field in {"event", "id"}:
+            event[field] = value
+
+    if data_lines:
+        event["data"] = "\n".join(data_lines)
+        yield event

--- a/packages/yuxi-cli/src/yuxi_cli/main.py
+++ b/packages/yuxi-cli/src/yuxi_cli/main.py
@@ -7,6 +7,7 @@ from rich.console import Console
 
 from yuxi_cli import __version__
 from yuxi_cli.agent_eval import AgentEvalError, AgentEvalOptions, run_langfuse_agent_experiment
+from yuxi_cli.chat_web import ChatWebError, run_web_chat
 from yuxi_cli.client import ClientError
 from yuxi_cli.commands import (
     CommandError,
@@ -161,6 +162,25 @@ def logout(
         _print_remote_context(store, remote)
         logout_command(store, remote, local_only, console)
     except (ConfigError, ClientError) as exc:
+        _handle_error(exc)
+
+
+@app.command()
+def chat(
+    remote: str | None = typer.Option(None, "--remote", help="Remote name."),
+    agent_slug: str = typer.Option(
+        "default-chatbot", "--agent-slug", help="Yuxi agent slug."
+    ),
+    no_open: bool = typer.Option(
+        False, "--no-open", help="Print URL without opening a browser."
+    ),
+):
+    """Start a temporary local web chat."""
+    store = _store()
+    try:
+        _print_remote_context(store, remote)
+        run_web_chat(store, remote, agent_slug, console, no_open=no_open)
+    except (ConfigError, ClientError, ChatWebError) as exc:
         _handle_error(exc)
 
 

--- a/packages/yuxi-cli/tests/test_chat_web.py
+++ b/packages/yuxi-cli/tests/test_chat_web.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import http.client
+import io
+import json
+import threading
+
+import pytest
+import yuxi_cli.chat_web as chat_web_module
+from rich.console import Console
+from yuxi_cli.chat_web import ChatWebError, ChatWebServer, _browser_events, run_web_chat
+from yuxi_cli.config import ConfigStore
+
+
+class FakeChatClient:
+    def __init__(self):
+        self.calls = []
+
+    def create_agent_chat_run(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"run_id": "run-1", "thread_id": "thread-1"}
+
+    def stream_agent_run_events(self, run_id):
+        assert run_id == "run-1"
+        yield {
+            "event": "messages",
+            "data": json.dumps(
+                {
+                    "payload": {
+                        "chunk": {
+                            "status": "loading",
+                            "stream_event": {
+                                "type": "message_delta",
+                                "message_id": "message-1",
+                                "content": "你",
+                            },
+                        }
+                    }
+                }
+            ),
+        }
+        yield {"event": "end", "data": json.dumps({"payload": {"status": "completed"}})}
+
+
+class BlockingChatClient(FakeChatClient):
+    def __init__(self):
+        super().__init__()
+        self.release_stream = threading.Event()
+
+    def stream_agent_run_events(self, run_id):
+        assert run_id == "run-1"
+        yield {
+            "event": "messages",
+            "data": json.dumps(
+                {
+                    "thread_id": "thread-1",
+                    "payload": {
+                        "chunk": {
+                            "stream_event": {
+                                "type": "message_delta",
+                                "content": "首包",
+                            }
+                        }
+                    },
+                }
+            ),
+        }
+        self.release_stream.wait(timeout=5)
+        yield {"event": "end", "data": json.dumps({"payload": {"status": "completed"}})}
+
+
+class TruncatedChatClient(FakeChatClient):
+    def stream_agent_run_events(self, run_id):
+        assert run_id == "run-1"
+        yield {
+            "event": "messages",
+            "data": json.dumps(
+                {
+                    "payload": {
+                        "chunk": {
+                            "stream_event": {
+                                "type": "message_delta",
+                                "content": "未完成",
+                            }
+                        }
+                    }
+                }
+            ),
+        }
+
+
+def test_browser_events_extracts_text_delta_and_terminal_status():
+    client = FakeChatClient()
+
+    assert list(_browser_events(client.stream_agent_run_events("run-1"))) == [
+        {"type": "delta", "content": "你"},
+        {"type": "done", "status": "completed"},
+    ]
+
+
+def test_browser_events_handles_retry_interrupt_and_child_thread():
+    events = iter(
+        [
+            {
+                "event": "error",
+                "data": json.dumps({"payload": {"chunk": {"retryable": True}}}),
+            },
+            {
+                "event": "messages",
+                "data": json.dumps(
+                    {
+                        "thread_id": "child-thread",
+                        "payload": {
+                            "chunk": {
+                                "stream_event": {
+                                    "type": "message_delta",
+                                    "content": "子线程",
+                                }
+                            }
+                        },
+                    }
+                ),
+            },
+            {
+                "event": "end",
+                "data": json.dumps(
+                    {"thread_id": "thread-1", "payload": {"status": "interrupted"}}
+                ),
+            },
+        ]
+    )
+
+    assert list(_browser_events(events, thread_id="thread-1")) == [
+        {"type": "error", "message": "运行结束：interrupted"},
+        {"type": "done", "status": "interrupted"},
+    ]
+
+
+def test_browser_events_rejects_eof_without_terminal_event():
+    events = TruncatedChatClient().stream_agent_run_events("run-1")
+
+    with pytest.raises(ChatWebError, match="终态前断开"):
+        list(_browser_events(events))
+
+
+def test_local_server_streams_chat_without_exposing_api_key():
+    client = FakeChatClient()
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, "default-chatbot", "session-secret"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+
+    try:
+        connection.request("GET", "/")
+        page_response = connection.getresponse()
+        page = page_response.read().decode()
+        assert page_response.status == 200
+        assert "session-secret" in page
+        assert "yxkey_" not in page
+
+        body = json.dumps({"message": "你好", "thread_id": None})
+        connection.request(
+            "POST",
+            "/api/chat",
+            body=body,
+            headers={
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body.encode())),
+                "Origin": server.origin,
+                "X-Yuxi-Chat-Token": "session-secret",
+            },
+        )
+        stream_response = connection.getresponse()
+        events = [
+            json.loads(line) for line in stream_response.read().decode().splitlines()
+        ]
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert stream_response.status == 200
+    assert events == [
+        {"type": "meta", "run_id": "run-1", "thread_id": "thread-1"},
+        {"type": "delta", "content": "你"},
+        {"type": "done", "status": "completed"},
+    ]
+    assert client.calls[0]["message"] == "你好"
+
+
+def test_local_server_flushes_delta_before_remote_stream_ends():
+    client = BlockingChatClient()
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, "default-chatbot", "session-secret"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+    body = json.dumps({"message": "流式测试", "thread_id": None})
+
+    try:
+        connection.request(
+            "POST",
+            "/api/chat",
+            body=body,
+            headers={
+                "Content-Type": "application/json",
+                "Origin": server.origin,
+                "X-Yuxi-Chat-Token": "session-secret",
+            },
+        )
+        response = connection.getresponse()
+        meta = json.loads(response.readline())
+        first_delta = json.loads(response.readline())
+
+        assert response.status == 200
+        assert meta["type"] == "meta"
+        assert first_delta == {"type": "delta", "content": "首包"}
+        assert client.release_stream.is_set() is False
+
+        client.release_stream.set()
+        remaining = [json.loads(line) for line in response.read().decode().splitlines()]
+        assert remaining == [{"type": "done", "status": "completed"}]
+    finally:
+        client.release_stream.set()
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_local_server_reports_truncated_remote_stream():
+    client = TruncatedChatClient()
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, "default-chatbot", "session-secret"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+    body = json.dumps({"message": "截断测试", "thread_id": None})
+
+    try:
+        connection.request(
+            "POST",
+            "/api/chat",
+            body=body,
+            headers={
+                "Content-Type": "application/json",
+                "Origin": server.origin,
+                "X-Yuxi-Chat-Token": "session-secret",
+            },
+        )
+        response = connection.getresponse()
+        events = [json.loads(line) for line in response.read().decode().splitlines()]
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 200
+    assert events[-2:] == [
+        {"type": "delta", "content": "未完成"},
+        {"type": "error", "message": "运行事件流在终态前断开，请重试"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_error"),
+    [
+        ({"Origin": "http://evil.example"}, "请求来源无效"),
+        ({"X-Yuxi-Chat-Token": "wrong-token"}, "会话令牌无效"),
+    ],
+)
+def test_local_server_rejects_untrusted_requests(headers, expected_error):
+    client = FakeChatClient()
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, "default-chatbot", "session-secret"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+    request_headers = {
+        "Origin": server.origin,
+        "X-Yuxi-Chat-Token": "session-secret",
+        **headers,
+    }
+
+    try:
+        connection.request("POST", "/api/chat", body="{}", headers=request_headers)
+        response = connection.getresponse()
+        payload = json.loads(response.read())
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 403
+    assert payload == {"error": expected_error}
+    assert client.calls == []
+
+
+def test_local_server_rejects_invalid_json():
+    client = FakeChatClient()
+    server = ChatWebServer(
+        ("127.0.0.1", 0), client, "default-chatbot", "session-secret"
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+
+    try:
+        connection.request(
+            "POST",
+            "/api/chat",
+            body="not-json",
+            headers={
+                "Origin": server.origin,
+                "X-Yuxi-Chat-Token": "session-secret",
+            },
+        )
+        response = connection.getresponse()
+        payload = json.loads(response.read())
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert response.status == 400
+    assert payload["error"]
+    assert client.calls == []
+
+
+def test_run_web_chat_requires_login(tmp_path):
+    store = ConfigStore(tmp_path / "config.toml")
+
+    with pytest.raises(ChatWebError, match="尚未登录"):
+        run_web_chat(store, None, "default-chatbot", console=None, no_open=True)
+
+
+def test_run_web_chat_opens_browser_and_closes_resources(tmp_path, monkeypatch):
+    store = ConfigStore(tmp_path / "config.toml")
+    config = store.load()
+    config.get_remote("local").api_key = "yxkey_test"
+    store.save(config)
+    opened_urls = []
+    fake_clients = []
+    fake_servers = []
+
+    class FakeClient:
+        def __init__(self, remote):
+            self.remote = remote
+            self.closed = False
+            fake_clients.append(self)
+
+        def close(self):
+            self.closed = True
+
+    class FakeServer:
+        origin = "http://127.0.0.1:43210"
+
+        def __init__(self, address, client, agent_slug, session_token):
+            assert address == ("127.0.0.1", 0)
+            assert agent_slug == "default-chatbot"
+            assert session_token
+            self.client = client
+            self.closed = False
+            fake_servers.append(self)
+
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+        def server_close(self):
+            self.closed = True
+
+    monkeypatch.setattr(chat_web_module, "YuxiClient", FakeClient)
+    monkeypatch.setattr(chat_web_module, "ChatWebServer", FakeServer)
+    console = Console(file=io.StringIO(), force_terminal=False)
+
+    run_web_chat(
+        store,
+        "local",
+        "default-chatbot",
+        console,
+        open_browser=lambda url: opened_urls.append(url) or True,
+    )
+
+    assert opened_urls == ["http://127.0.0.1:43210"]
+    assert fake_servers[0].closed is True
+    assert fake_clients[0].closed is True

--- a/packages/yuxi-cli/tests/test_client.py
+++ b/packages/yuxi-cli/tests/test_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from yuxi_cli.client import YuxiClient
+import httpx
+
+from yuxi_cli.client import YuxiClient, _iter_sse_events
 from yuxi_cli.config import Remote
 
 
@@ -37,6 +39,77 @@ def test_run_agent_eval_uses_invocation_endpoint(monkeypatch):
     assert call["json"]["agent_slug"] == "default-chatbot"
     assert call["json"]["evaluation"] == {"dataset_name": "dataset-1"}
     assert call["json"]["meta"] == {"request_id": "req-1"}
+
+
+def test_create_agent_chat_run_uses_async_reject_mode(monkeypatch):
+    client, calls = _patched_client(monkeypatch)
+    try:
+        client.create_agent_chat_run(
+            message="你好",
+            agent_slug="default-chatbot",
+            thread_id="thread-1",
+            request_id="request-1",
+        )
+    finally:
+        client.close()
+
+    call = calls[-1]
+    assert call["method"] == "POST"
+    assert call["path"] == "/agent-invocation/agent-call/runs"
+    assert call["json"] == {
+        "agent_slug": "default-chatbot",
+        "messages": [{"role": "user", "content": "你好"}],
+        "thread_id": "thread-1",
+        "request_id": "request-1",
+        "async_mode": True,
+        "queue_policy": "reject",
+    }
+
+
+def test_iter_sse_events_supports_multiline_data_and_ignores_heartbeat():
+    lines = iter(
+        [
+            ": heartbeat",
+            "",
+            "id: 1-0",
+            "event: messages",
+            'data: {"payload":',
+            'data: {"status":"loading"}}',
+            "",
+        ]
+    )
+
+    assert list(_iter_sse_events(lines)) == [
+        {
+            "id": "1-0",
+            "event": "messages",
+            "data": '{"payload":\n{"status":"loading"}}',
+        }
+    ]
+
+
+def test_stream_agent_run_events_sends_auth_and_uses_compact_events():
+    remote = Remote(name="local", url="http://localhost:5173", api_key="yxkey_test")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/agent/runs/run-1/events"
+        assert request.url.params["verbose"] == "false"
+        assert request.headers["Authorization"] == "Bearer yxkey_test"
+        return httpx.Response(
+            200,
+            text='event: end\ndata: {"payload":{"status":"completed"}}\n\n',
+            headers={"Content-Type": "text/event-stream"},
+        )
+
+    client = YuxiClient(remote)
+    client.client.close()
+    client.client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        events = list(client.stream_agent_run_events("run-1"))
+    finally:
+        client.close()
+
+    assert events == [{"event": "end", "data": '{"payload":{"status":"completed"}}'}]
 
 
 def test_list_external_databases_uses_external_path(monkeypatch):

--- a/packages/yuxi-cli/tests/test_main.py
+++ b/packages/yuxi-cli/tests/test_main.py
@@ -34,6 +34,29 @@ def test_kb_upload_help_is_registered():
     assert "1-300" in output
 
 
+def test_chat_command_starts_web_chat(tmp_path, monkeypatch):
+    store = ConfigStore(tmp_path / "config.toml")
+    config = store.load()
+    config.get_remote("local").api_key = "yxkey_test"
+    store.save(config)
+    calls = []
+
+    def fake_run_web_chat(store_arg, remote, agent_slug, console, *, no_open):
+        calls.append((store_arg, remote, agent_slug, console, no_open))
+
+    monkeypatch.setattr("yuxi_cli.main._store", lambda: store)
+    monkeypatch.setattr("yuxi_cli.main.run_web_chat", fake_run_web_chat)
+
+    result = CliRunner().invoke(
+        app, ["chat", "--agent-slug", "debug-agent", "--no-open"]
+    )
+
+    assert result.exit_code == 0
+    assert calls[0][0] is store
+    assert calls[0][1:3] == (None, "debug-agent")
+    assert calls[0][4] is True
+
+
 def test_remote_command_prints_version_and_remote_context_first(tmp_path, monkeypatch):
     store = ConfigStore(tmp_path / "config.toml")
     config = store.load()


### PR DESCRIPTION
## 变更描述

本 PR 在正式接入 IM 之前，先提供一个独立、简单的 CLI 网页聊天入口：

```bash
uvx --from yuxi-cli yuxi chat
```

命令会在 `127.0.0.1` 启动临时本地代理并打开浏览器，通过现有 Agent Call / Agent Run SSE 完成流式聊天。API Key 只保留在 Python 代理进程内，不进入 HTML、浏览器存储或前端请求。

本 PR 同时记录了 Agent Interrupt / Resume 与纯文本 IM 接入的讨论方案。方案用于后续评审，不在本 PR 修改 backend 或提前承诺公共接口。

关联议题：#837

## 实现内容

### CLI 网页聊天

- 新增 `yuxi chat`，不需要 `--web`。
- 本地服务只监听 `127.0.0.1`，启动后自动打开浏览器。
- Python 代理读取当前 CLI remote 与 API Key，并转发 Agent Call 请求和 Run SSE。
- 浏览器按 SSE `delta` 逐步渲染回复，只有收到 `done/completed` 才认为成功。
- 上游 SSE 在终态前 EOF 时明确报错，不把截断误判成正常完成。
- 连续消息复用同一个 `thread_id`；“新对话”创建新的 thread。
- 使用随机 session token 与 Origin 检查约束本地代理请求。
- `chat.html` 作为 package data 进入 wheel / sdist。
- 更新 CLI 使用文档、README 与 changelog。

### 当前边界

- 没有修改 `backend/`。
- 当前 CLI 实现使用 Agent Call 创建 Run、使用 Agent Run SSE 消费流；这是本 PR 的最小调试实现。
- 进一步核对后确认：富客户端不需要在 Agent Call 下新增一套 Interrupt / Resume API，应直接复用 Web 已经使用的 Agent Run / Chat API。
- 本 PR 暂不继续修改实现；下方方案以现有 Agent Run API 为基础，重点收敛到纯文本 IM 的 slash command、过期处理和渠道消息路由。

## Interrupt / Resume 与 IM 方案

分支中的 [`docs/vibe/2026-07-25-agent-interrupt-resume-and-im-adapter.md`](docs/vibe/2026-07-25-agent-interrupt-resume-and-im-adapter.md) 保留第一轮调研过程；本 PR 正文是讨论后的当前方案，发生冲突时以本节为准。

调研参考了固定源码快照：

- [NousResearch/hermes-agent@8f8b66d](https://github.com/NousResearch/hermes-agent/tree/8f8b66d8ac6ed5172daa213b615037cae0ed92f9)
- [openclaw/openclaw@d4a90c7](https://github.com/openclaw/openclaw/tree/d4a90c7bbb69b78990582a3b8952ff99f1812fa3)
- [openocta/openocta@c4c5bd3](https://github.com/openocta/openocta/tree/c4c5bd3e839707cb3b844c051f21dc36ced09eb8)

### 方案目标

方案分为两条能力线，但不再新增独立 Interrupt 表或 `interrupt_id`：

#### 1. 富客户端：CLI / Web / SDK

富客户端直接使用 Web 已经使用的 Agent Run / Chat API：

```text
POST /api/agent/runs
  -> queued 时订阅 Request SSE
  -> 派发后订阅 Run SSE
  -> 收到 questions / approval / interrupt_info
  -> 客户端渲染问题或审批
  -> POST /api/agent/runs，携带 resume + created_by_run_id
  -> 订阅新 Resume Run 的 SSE
```

现有接口已经覆盖：

```http
POST /api/agent/runs
GET  /api/agent/requests/{request_id}/events
GET  /api/agent/runs/{run_id}
GET  /api/agent/runs/{run_id}/events
POST /api/agent/runs/{run_id}/cancel
GET  /api/agent/thread/{thread_id}/active_run
```

因此不新增 Agent Call Resume。Agent Call 继续用于同步调用、评测和 OpenAI-compatible 场景；交互式富客户端直接适配 Agent Run API。

当前 Run SSE 中的完整 Interrupt 事件默认保留在 Redis 两小时，但 Interrupt 本身已经由 LangGraph checkpoint 持久化到 PostgreSQL。后续只需让现有 Thread/Run 状态查询能够从 checkpoint 重新提取 `questions` 或 `approval`，不再重复保存 payload。

#### 2. 纯文本 IM

本阶段的重点是纯文本 IM。只能收发文字的渠道把消息送入统一内部 ingestion；slash command 和待回答问题的 claim 必须先于普通 Agent 消息分发，避免“线程等待审批，而审批回复又被普通消息入口拒绝”的死锁：

```text
平台 webhook
  -> 渠道 Adapter 验签、时间窗和首次去重
  -> 统一内部 ingestion 验证 Adapter 服务身份与 binding
  -> Slash command / pending question 解析
  -> resolve interrupt，或分发为普通 Agent 消息
```

推荐最小命令集：

```text
/pending
/approve <run_id>
/reject <run_id> [reason]
/answer <run_id> <text>
/cancel <run_id>
/help
```

`interrupted_run_id` 已经是稳定目标，不再生成额外 Interrupt ID。审批默认不接受普通“是”“运行”等自然文本，必须携带 Run ID 或来自可信按钮回调。问题回答在“同一私聊、同一 actor、恰好一个 pending question、没有歧义”时可以把下一条普通文本 claim 为答案；群聊或多个 pending 时必须使用 `/answer <run_id>`。

### Interrupt 的事实来源与过期

不新增 Interrupt 表，也不把完整 payload 复制到 AgentRun：

```text
AgentRun.status=interrupted        运行事实
AgentRun.error_type                interrupt 类型
LangGraph checkpoint              questions / approval 完整 payload
ResumeRun.created_by_run_id        恢复关系
ResumeRun.input_payload            实际回答或审批决议
```

只建议在 AgentRun 增加一个轻量字段：

```text
interrupt_expires_at: datetime | null
```

它固定该次等待的有效期，避免修改全局 TTL 后追溯改变历史 Run；payload 仍从 checkpoint 读取。

过期不能只把数据库状态改成 completed/cancelled，因为 LangGraph checkpoint 仍停在 `interrupt()`。推荐通过安全的系统 Resume 解除 checkpoint：

- 工具审批过期：为所有 action request 提交 `reject`；
- `ask_user_question` 过期：Resume 明确的 expired/cancel 哨兵，让工具得到“用户未在有效期内回答”；
- 系统 Resume Run 完成后，线程恢复接收普通消息；
- 第一版可以在 `/pending`、slash command 或新消息到达时惰性处理，后续再增加周期扫描。

过期后，显式 `/answer <run_id>` 或 `/approve <run_id>` 只返回“请求已过期”，不能流入普通 Agent 消息；没有 slash command 的普通文本则先安全过期旧 Interrupt，再作为新的普通消息排队。

### 幂等与并发

- 一个 interrupted Run 只能创建一个有效的用户 Resume 或系统过期 Resume。
- 幂等记录必须绑定 parent run、canonical decisions/answers、actor、tenant 与授权 scope。
- 相同 key、相同 actor、相同 payload 才返回第一次创建的 run。
- 相同 key 但改变 approve/reject、答案或 actor，返回 `409 idempotency_key_conflict`。
- 用户回答与过期处理必须锁定同一个 parent run，只允许一个创建 Resume；其余返回 already-resolved / superseded / expired。
- SSE 只负责低延迟通知，Run / Thread 查询接口是断线恢复的事实来源。

### Slash command 代码边界

Slash command 不放进 `agent_invocation_router.py`。该 Router 继续只负责 Agent Call 与 Evaluation；渠道消息具有平台验签、Adapter binding、sender 鉴权、消息去重和命令抢占等不同语义。

建议最小结构：

```text
backend/server/routers/channel_invocation_router.py
  -> HTTP 请求模型与 Adapter 服务身份认证

backend/package/yuxi/services/channel_message_service.py
  -> conversation 映射
  -> slash command 优先处理
  -> pending question 文本 claim
  -> 普通 Agent Run 分发

backend/package/yuxi/services/channel_command_service.py
  -> /pending /approve /reject /answer /cancel /help
  -> 复用 agent_run_service 创建 Resume 或取消 Run
```

第一版不做复杂的插件式 Command Registry；使用一个严格、独立、可单元测试的解析入口即可。

### Adapter 信任边界

外部 webhook 与内部 ingestion 是两个信任层：

- Adapter 验证平台原始签名和时间窗，并提取 provider identity。
- Adapter 到核心服务使用 mTLS、请求 HMAC 或 OAuth service principal。
- 核心根据服务身份与 `adapter_binding_id` 派生允许的 tenant / channel / account，不能信任信封自报的身份或 `signature_context`。
- 核心再次按 provider `message_id` 去重。
- 群聊内能看到消息不等于有审批权；actor authorization 必须单独判断。

### 推荐实施阶段

1. 富客户端复用并文档化现有 Agent Run API；状态查询从 LangGraph checkpoint 恢复 Interrupt payload。
2. 增加 `interrupt_expires_at` 与安全过期 Resume，处理回答/过期竞态。
3. 实现独立 Channel Message / Slash Command 服务、actor authorization、消息去重、幂等和审计。
4. 选择一个可稳定测试 webhook 的 IM；Adapter 只做平台适配，不复制 Resume 逻辑。
5. 扩展多渠道与按钮渲染，所有渠道仍回到同一 command/resume 服务。

### 待讨论问题

- `interrupt_expires_at` 的默认时长，以及问题与工具审批是否使用不同 TTL。
- 问题过期哨兵的稳定 payload 结构，以及过期 Resume 是否允许 Agent 输出一条说明。
- 私聊唯一 pending question 是否默认允许隐式文本回答。
- 第一版是否只支持单次 approve/reject，不开放 `allow-always`。
- 多个 action request 是逐项决议，还是允许 UI 提供显式的整组批准。
- 首个 IM 平台与渠道账号到 Yuxi 用户的绑定方式。
- `/cancel <run_id>` 是否同时覆盖 active Run 与 interrupted Run，还是单独增加 `/reject <run_id>` 作为关闭等待的唯一方式。

## 变更类型

- [x] 新功能
- [ ] Bug 修复
- [x] 文档更新
- [ ] 其他

## 测试

- [x] 已在 Docker 环境测试
- [x] 相关功能正常工作

实际验证：

- Python 3.12：`86 passed`
- Docker Python 3.13：`86 passed`
- Python 3.14：`86 passed`
- 提交前回归：`86 passed in 4.48s`
- 新文件 Ruff check / format：通过
- 变更 Python 文件关键 `E4,E7,E9,F` 规则：通过
- `py_compile`、staged `git diff --check`：通过
- wheel / sdist 构建通过，`chat.html` 已包含在 wheel 中
- `uvx --from <wheel> yuxi chat --help`：通过

真实 E2E 使用本地 Docker 环境和有效 API Key 完成：

- 上游返回多个 delta，浏览器观察到中间“生成中”状态与最终回答；
- 同一会话第二轮复用 thread，并正确利用上文；
- “新对话”生成不同 thread；
- 390px 与 1200px 宽度无水平溢出；
- 浏览器 console 无错误；
- API Key 未进入 HTML / JS / console；
- SSE 在终态前截断时输出明确 error，不误报 success。

全包使用当前最新版 Ruff 会报告 27 项既有规范问题，分布在既有 Typer、KB 与测试代码中；本 PR 未扩大范围清理这些问题，目标文件检查已通过。

**相关日志或者截图**

本 PR 记录了上述真实浏览器与 Docker E2E 结果；未上传包含本地会话内容的截图，避免携带开发环境用户数据。

## 影响范围

- `packages/yuxi-cli`：新增网页聊天命令、SSE 客户端方法、静态页面和测试。
- CLI 用户文档、README、changelog。
- `docs/vibe`：新增 Interrupt / Resume 与 IM 接入讨论稿。
- `backend/`：无代码变更。

## Human Review / AI 贡献说明

- AI 工具：OpenAI Codex。
- 独立 Agent Code Review：2 个独立审阅任务，发现的 SSE EOF 终态问题已修复并复核通过；最终无未解决 finding。
- 方案 Review：独立审阅发现 ingestion 信任边界、幂等键绑定和状态语义问题，均修正并最终复核通过。
- Human Review：1 次。用户于 2026-07-25 明确确认已人工阅读全部改动、检查任务范围和安全风险，并认可测试结果。

## 说明

- 这是 Draft PR。Interrupt / Resume 与 IM 内容是待讨论方案，本 PR 不实现 backend 接口。
- #837 保持原始正文，本 PR 不自动关闭该 Issue。
- Draft 阶段不会自动转为 Ready，也不会由 Agent 合并。

---

💡 **提示**: 提交前可以运行 `make lint` 和 `make format` 检查代码规范
