### PR TITLE
feat(storage): support public MinIO reverse-proxy URLs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,9 +26,13 @@ TAVILY_API_KEY=  # 获取搜索服务的 api key 请访问 https://app.tavily.co
 # NEO4J_PASSWORD=
 # # endregion neo4j
 
-# # Servies
+# # Services
 # YUXI_SUPER_ADMIN_NAME=
 # YUXI_SUPER_ADMIN_PASSWORD=
+
+# Optional public MinIO object URL. Set this when a reverse proxy serves MinIO
+# under the Yuxi origin, for example: https://yuxi.example.com/storage
+# MINIO_PUBLIC_URI=
 
 # # URL Whitelist (comma-separated domains/IPs, empty to disable URL parsing)
 # YUXI_URL_WHITELIST=github.com,docs.example.com,gitlab.example.com,127.0.0.1

--- a/src/storage/minio/client.py
+++ b/src/storage/minio/client.py
@@ -9,6 +9,7 @@ import os
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from io import BytesIO
+from urllib.parse import urlparse
 
 from urllib3 import BaseHTTPResponse
 
@@ -67,19 +68,22 @@ class MinIOClient:
         self.secret_key = os.getenv("MINIO_SECRET_KEY") or "minioadmin"
         self._client = None
 
-        # 设置公开访问端点
-        if os.getenv("RUNNING_IN_DOCKER"):
-            host_ip = (os.getenv("HOST_IP") or "").strip()
-            if not host_ip:
-                host_ip = "localhost"
+        # Public URLs may be served through an application reverse proxy rather
+        # than by exposing MinIO's port directly.
+        public_uri = (os.getenv("MINIO_PUBLIC_URI") or "").strip().rstrip("/")
+        if public_uri:
+            parsed_public_uri = urlparse(public_uri)
+            if parsed_public_uri.scheme not in {"http", "https"} or not parsed_public_uri.hostname:
+                raise StorageError("MINIO_PUBLIC_URI 必须是有效的 http/https URL")
+            self.public_base_url = public_uri
+        elif os.getenv("RUNNING_IN_DOCKER"):
+            host_ip = (os.getenv("HOST_IP") or "localhost").strip()
             if "://" in host_ip:
-                host_ip = host_ip.split("://")[-1]
-            host_ip = host_ip.rstrip("/")
-            self.public_endpoint = f"{host_ip}:9000"
-            logger.debug(f"Docker MinIOClient public_endpoint: {self.public_endpoint}")
+                host_ip = host_ip.split("://", 1)[-1]
+            self.public_base_url = f"http://{host_ip.rstrip('/')}:9000"
         else:
-            self.public_endpoint = "localhost:9000"
-            logger.debug(f"Default_client: {self.public_endpoint}")
+            self.public_base_url = "http://localhost:9000"
+        logger.debug(f"MinIOClient public_base_url: {self.public_base_url}")
 
     @property
     def client(self) -> Minio:
@@ -132,7 +136,7 @@ class MinIOClient:
             )
 
             assert result is not None
-            url = f"http://{self.public_endpoint}/{bucket_name}/{object_name}"
+            url = f"{self.public_base_url}/{bucket_name}/{object_name}"
 
             return UploadResult(url, bucket_name, object_name)
 
@@ -365,7 +369,6 @@ class MinIOClient:
             StorageError: 如果 URL 无效或下载失败
         """
         import tempfile
-        from urllib.parse import urlparse
 
         # 验证 URL
         if not url or not isinstance(url, str):
@@ -378,12 +381,13 @@ class MinIOClient:
 
         parsed = urlparse(url)
 
-        # 验证主机
+        # URL must belong to the private MinIO endpoint or the explicitly
+        # configured public reverse-proxy endpoint.
         endpoint_host = self.endpoint.split("://")[-1].split(":")[0]
-        url_host = parsed.netloc.split(":")[0]
-
-        if endpoint_host != url_host and url_host != os.environ.get("HOST_IP", "localhost"):
-            raise StorageError(f"不允许的外部 URL: {url_host}")
+        public_uri = urlparse(self.public_base_url)
+        allowed_hosts = {endpoint_host, public_uri.hostname or ""}
+        if parsed.hostname not in allowed_hosts:
+            raise StorageError(f"不允许的外部 URL: {parsed.hostname}")
 
         # 检查路径遍历
         if ".." in url or "\\" in url:
@@ -393,8 +397,14 @@ class MinIOClient:
         if allowed_extensions and not any(url.endswith(ext) for ext in allowed_extensions):
             raise StorageError(f"文件扩展名不符合要求，允许: {', '.join(allowed_extensions)}")
 
-        # 解析 bucket 和 object name
-        path_parts = parsed.path.lstrip("/").split("/", 1)
+        # Parse bucket and object name, removing the configured public prefix.
+        object_path = parsed.path
+        public_prefix = public_uri.path.rstrip("/")
+        if parsed.hostname == public_uri.hostname and public_prefix:
+            if object_path != public_prefix and not object_path.startswith(f"{public_prefix}/"):
+                raise StorageError("URL 不属于配置的 MinIO 公开路径")
+            object_path = object_path[len(public_prefix) :]
+        path_parts = object_path.lstrip("/").split("/", 1)
         if len(path_parts) != 2:
             raise StorageError("无法解析 MinIO URL")
 

--- a/test/test_minio_public_uri.py
+++ b/test/test_minio_public_uri.py
@@ -1,0 +1,91 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_client_module():
+    """Load the storage client without triggering the app's eager graph setup."""
+    src_module = types.ModuleType("src")
+    utils_module = types.ModuleType("src.utils")
+    utils_module.logger = logging.getLogger("test.minio")
+    sys.modules.setdefault("src", src_module)
+    sys.modules.setdefault("src.utils", utils_module)
+
+    source = Path(__file__).parents[1] / "src" / "storage" / "minio" / "client.py"
+    spec = importlib.util.spec_from_file_location("minio_client_under_test", source)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+client_module = _load_client_module()
+MinIOClient = client_module.MinIOClient
+StorageError = client_module.StorageError
+
+
+def test_minio_upload_uses_configured_public_reverse_proxy_uri(monkeypatch) -> None:
+    monkeypatch.setenv("MINIO_URI", "http://minio:9000")
+    monkeypatch.setenv("MINIO_PUBLIC_URI", "https://example.test/storage/")
+    client = MinIOClient()
+
+    class FakeMinio:
+        def put_object(self, **_kwargs):
+            return object()
+
+    client._client = FakeMinio()
+    monkeypatch.setattr(client, "ensure_bucket_exists", lambda bucket_name: True)
+
+    result = client.upload_file("avatar", "user.png", b"image")
+
+    assert result.url == "https://example.test/storage/avatar/user.png"
+
+
+@pytest.mark.asyncio
+async def test_minio_public_uri_maps_proxy_path_back_to_bucket(monkeypatch) -> None:
+    monkeypatch.setenv("MINIO_URI", "http://minio:9000")
+    monkeypatch.setenv("MINIO_PUBLIC_URI", "https://example.test/storage")
+    client = MinIOClient()
+    downloaded = []
+
+    async def fake_download(bucket_name: str, object_name: str) -> bytes:
+        downloaded.append((bucket_name, object_name))
+        return b"image"
+
+    monkeypatch.setattr(client, "adownload_file", fake_download)
+
+    async with client.temp_file_from_url(
+        "https://example.test/storage/avatar/user.png",
+        allowed_extensions=[".png"],
+    ) as temp_file:
+        assert Path(temp_file).read_bytes() == b"image"
+
+    assert downloaded == [("avatar", "user.png")]
+    assert not Path(temp_file).exists()
+
+
+@pytest.mark.asyncio
+async def test_minio_public_uri_rejects_external_host_and_wrong_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("MINIO_URI", "http://minio:9000")
+    monkeypatch.setenv("MINIO_PUBLIC_URI", "https://example.test/storage")
+    client = MinIOClient()
+
+    with pytest.raises(StorageError, match="不允许的外部 URL"):
+        async with client.temp_file_from_url("https://evil.example/avatar/user.png"):
+            pass
+
+    with pytest.raises(StorageError, match="不属于配置的 MinIO 公开路径"):
+        async with client.temp_file_from_url("https://example.test/other/avatar/user.png"):
+            pass
+
+
+def test_minio_public_uri_requires_valid_http_url(monkeypatch) -> None:
+    monkeypatch.setenv("MINIO_PUBLIC_URI", "https://")
+
+    with pytest.raises(StorageError, match="有效的 http/https URL"):
+        MinIOClient()


### PR DESCRIPTION
## Summary

Allow deployments that keep MinIO private and expose objects through an application reverse proxy.

- Add optional `MINIO_PUBLIC_URI` (for example `https://yuxi.example.com/storage`).
- Generate uploaded object URLs from that public base rather than exposing `:9000`.
- Accept only the configured public host and prefix when downloading one of those URLs back into a temporary file.
- Preserve current `HOST_IP` / localhost behavior when `MINIO_PUBLIC_URI` is unset.

## Why

Many production deployments do not publish MinIO directly. Returning `http://<host>:9000/...` produces inaccessible or mixed-origin URLs; the configurable public base allows same-origin reverse-proxy deployments without weakening URL validation.

## Tests

```text
TEST_USERNAME=unit-test TEST_PASSWORD=unit-test .venv/Scripts/python.exe -m pytest test/test_minio_public_uri.py -q
# 4 passed
.venv/Scripts/ruff.exe check src/storage/minio/client.py test/test_minio_public_uri.py
# All checks passed
```

The focused test module loads the storage client without importing the application's eager graph bootstrap, so it has no Neo4j dependency.
