### PR TITLE
fix(sandbox): support external OIDC subjects in workspace paths

### DIFF
--- a/backend/package/yuxi/agents/backends/sandbox/paths.py
+++ b/backend/package/yuxi/agents/backends/sandbox/paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import re
 from pathlib import Path
 
@@ -36,18 +37,25 @@ def _thread_root_dir(thread_id: str) -> Path:
     return Path(conf.save_dir) / "threads" / safe_thread_id / "user-data"
 
 
-def _validate_uid(uid: str) -> str:
+def _workspace_uid_dirname(uid: str) -> str:
+    """Return a path-safe, stable workspace directory name for a logical UID.
+
+    Database and OIDC subject identifiers may contain characters such as ``:``
+    that are valid identity data but unsafe in filesystem path components.
+    Legacy simple UIDs retain their directory name; all other values use a
+    namespaced SHA-256 digest at the filesystem boundary only.
+    """
     value = str(uid or "").strip()
     if not value:
         raise ValueError("uid is required")
-    if not _SAFE_ID_RE.match(value):
-        raise ValueError("uid contains invalid characters")
-    return value
+    if _SAFE_ID_RE.fullmatch(value):
+        return value
+    return f"uid-{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
 
 
 def _global_user_data_dir(uid: str) -> Path:
     """Return the shared host-side directory used for one user's workspace files."""
-    safe_uid = _validate_uid(uid)
+    safe_uid = _workspace_uid_dirname(uid)
     return Path(conf.save_dir) / "threads" / "shared" / safe_uid
 
 

--- a/backend/package/yuxi/agents/backends/sandbox/provider.py
+++ b/backend/package/yuxi/agents/backends/sandbox/provider.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 from yuxi.utils.logging_config import logger
 
+from .paths import _workspace_uid_dirname
 from .provisioner_client import ProvisionerClient, SandboxRecord
 
 
@@ -173,7 +174,7 @@ class ProvisionerSandboxProvider:
             record = self._client.create(
                 sandbox_id,
                 thread_id,
-                uid,
+                _workspace_uid_dirname(uid),
                 load_user_agent_env(uid),
                 file_thread_id=file_id,
                 skills_thread_id=skills_id,
@@ -221,7 +222,7 @@ class ProvisionerSandboxProvider:
                 record = self._client.create(
                     sandbox_id,
                     thread_id,
-                    uid,
+                    _workspace_uid_dirname(uid),
                     load_user_agent_env(uid),
                     file_thread_id=file_id,
                     skills_thread_id=skills_id,

--- a/backend/test/unit/backends/test_sandbox_backends.py
+++ b/backend/test/unit/backends/test_sandbox_backends.py
@@ -383,6 +383,37 @@ def test_provider_uses_distinct_sandbox_scope_for_different_uid(monkeypatch) -> 
     assert created[1][2] == "user-2"
 
 
+def test_provider_maps_external_uid_only_at_provisioner_filesystem_boundary(monkeypatch) -> None:
+    from yuxi.agents.backends.sandbox.paths import _workspace_uid_dirname
+    from yuxi.agents.backends.sandbox.provider import ProvisionerSandboxProvider
+
+    calls = []
+
+    class FakeClient:
+        def create(self, sandbox_id, thread_id, uid, env, *, file_thread_id=None, skills_thread_id=None):
+            calls.append((uid, env))
+            return SimpleNamespace(sandbox_id=sandbox_id, sandbox_url="http://sandbox")
+
+        def touch(self, _sandbox_id):
+            return True
+
+    provider = ProvisionerSandboxProvider.__new__(ProvisionerSandboxProvider)
+    provider._client = FakeClient()
+    provider._lock = threading.Lock()
+    provider._thread_locks = {}
+    provider._connections = {}
+    provider._last_touch_at = {}
+    provider._touch_interval_seconds = 30
+    logical_uid = "oidc:12345678-1234-1234-1234-123456789abc"
+    monkeypatch.setattr("yuxi.agents.backends.sandbox.provider.load_user_agent_env", lambda uid: {"OWNER": uid})
+
+    provider.acquire("thread-1", uid=logical_uid)
+
+    assert calls == [(_workspace_uid_dirname(logical_uid), {"OWNER": logical_uid})]
+    assert calls[0][0].startswith("uid-")
+    assert ":" not in calls[0][0]
+
+
 def test_provider_get_create_if_missing_ensures_expected_split_scope(monkeypatch) -> None:
     from yuxi.agents.backends.sandbox.provider import ProvisionerSandboxProvider
 

--- a/backend/test/unit/services/test_workspace_service.py
+++ b/backend/test/unit/services/test_workspace_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +39,28 @@ def test_ensure_thread_dirs_creates_default_agent_context_files(tmp_path: Path, 
     agents_dir = tmp_path / "threads" / "shared" / "user-1" / "workspace" / "agents"
     assert {path.name for path in agents_dir.iterdir()} == {"AGENTS.md", "USER.md", "MEMORY.md"}
     assert all(path.read_text(encoding="utf-8").strip() for path in agents_dir.iterdir())
+
+
+def test_external_uid_uses_stable_path_safe_workspace_directory(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(workspace_paths.conf, "save_dir", str(tmp_path))
+    uid = "oidc:898f3d04-140e-433b-a06e-1e50a2bd01b6"
+
+    workspace_paths.ensure_thread_dirs("thread-1", uid)
+
+    dirname = "uid-" + hashlib.sha256(uid.encode("utf-8")).hexdigest()
+    workspace = workspace_paths.sandbox_workspace_dir("thread-1", uid)
+    assert workspace == tmp_path / "threads" / "shared" / dirname / "workspace"
+    assert (workspace / "agents" / "AGENTS.md").is_file()
+
+
+@pytest.mark.parametrize("uid", ["../outside", r"C:\\outside", "oidc:tenant/user"])
+def test_external_uid_cannot_escape_threads_root(tmp_path: Path, monkeypatch, uid: str) -> None:
+    monkeypatch.setattr(workspace_paths.conf, "save_dir", str(tmp_path / "saves"))
+
+    workspace = workspace_paths.sandbox_workspace_dir("thread-1", uid)
+
+    assert workspace.parent.name == "uid-" + hashlib.sha256(uid.encode("utf-8")).hexdigest()
+    assert workspace.resolve().is_relative_to((tmp_path / "saves" / "threads").resolve())
 
 
 def test_workspace_root_keeps_existing_agents_prompt_file(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

External identity providers commonly use subjects that contain `:` or `/` (for example `oidc:<uuid>`). Those are valid logical identities but currently fail Sandbox UID validation because the same value is used as a filesystem directory name.

This patch separates the two concerns:

- Preserve existing safe UIDs unchanged for backward-compatible workspace paths.
- Derive a stable `uid-<sha256>` directory name only when an external UID contains filesystem-unsafe characters.
- Keep the original logical UID for database lookups, sandbox cache ownership, IDs, and agent environment resolution.
- Pass only the safe directory identifier to the provisioner, where it becomes a host bind-mount path component.

This prevents path traversal / Windows drive-like values from escaping `saves/threads` while allowing standard OIDC subjects.

## Tests

Added coverage for:

- Stable OIDC UID workspace mapping.
- `../`, Windows drive-like, and slash-containing values remaining inside the threads root.
- Provisioner receiving the mapped filesystem UID while its environment lookup retains the original logical UID.

Validation run locally:

```text
ruff check ...  -> All checks passed
python -m py_compile ... -> passed
```

The focused pytest invocation could not complete locally because the newly-created backend environment timed out while downloading the project's CPU PyTorch dependency before collection. The tests are self-contained and do not require a live model, database, or sandbox service once project dependencies are installed.
