### PR TITLE
fix: Makefile 补充真实可用的 lint/test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,13 @@ format:
 	cd backend && UV_PYTHON=$(BACKEND_PYTHON) uv run ruff check --select I package --fix
 	cd web && pnpm run format
 	cd web && pnpm run lint
+
+# 只检查不修改，供提交前与 CI 使用（与 ruff.yml 的命令保持一致）
+lint:
+	cd backend && UV_PYTHON=$(BACKEND_PYTHON) uv run ruff check package
+	cd backend && UV_PYTHON=$(BACKEND_PYTHON) uv run ruff check --select I package
+	cd web && pnpm run lint
+
+# 后端单元测试（不依赖 docker 服务）；integration/e2e 需在容器环境运行
+test:
+	cd backend && UV_PYTHON=$(BACKEND_PYTHON) uv run pytest -m unit $(PYTEST_ARGS)


### PR DESCRIPTION
Fixes #868

## 变更描述
Makefile 的 .PHONY 声明了 lint 却无 recipe，`make lint` 静默无操作。补充 `lint`（ruff check 只检查不修复）与 `test`（pytest -m unit）两个 target。

## 变更类型
- [x] Bug 修复

## 测试
- [x] `make -n lint` / `make -n test` 语法验证通过
- [ ] Docker 环境测试（待 CI）