### PR TITLE
fix: backend 包补充 MIT license 元数据

### DIFF
--- a/backend/package/pyproject.toml
+++ b/backend/package/pyproject.toml
@@ -7,6 +7,10 @@ name = "yuxi"
 version = "0.7.1"
 description = "Yuxi 智能知识库与知识图谱平台核心后端包"
 readme = "README.md"
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "agent-sandbox>=0.0.26",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,6 +3,10 @@ name = "yuxi-workspace"
 version = "0.7.1"
 description = "基于大模型的智能知识库与知识图谱智能体开发平台，融合了 RAG 技术与知识图谱技术，基于 LangGraph v1 + Vue.js + FastAPI + LightRAG 架构构建"
 readme = "README.md"
+license = { text = "MIT" }
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastapi>=0.121",


### PR DESCRIPTION
Fixes #871

## 变更描述
backend/pyproject.toml 与 backend/package/pyproject.toml（yuxi 核心包）补 license = MIT 与 License classifier，与根 LICENSE(MIT) 一致。

## 变更类型
- [x] Bug 修复

## 测试
- [ ] 待 CI 验证