### PR TITLE
fix: ARQ job_timeout 改为可配置

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,6 +41,8 @@ NEO4J_PASSWORD=
 # # Servies
 # YUXI_SUPER_ADMIN_NAME=
 # YUXI_SUPER_ADMIN_PASSWORD=
+# # ARQ worker 单任务最长执行时间（秒），默认 3600，长耗时任务需调大
+# YUXI_JOB_TIMEOUT_SECONDS=3600
 
 # # URL Whitelist (comma-separated domains/IPs, empty to disable URL parsing)
 # YUXI_URL_WHITELIST=github.com,docs.example.com,gitlab.example.com,127.0.0.1

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import time
 from dataclasses import dataclass, field
 
@@ -670,7 +671,9 @@ class WorkerSettings:
     functions = [process_agent_run]
     max_tries = 2
     retry_jobs = True
-    job_timeout = 3600
+    # 单任务最长执行时间（秒），可配置：超长图谱构建/深度检索场景需调大，
+    # 避免长任务被 arq 取消并误标为 cancelled。
+    job_timeout = int(os.getenv("YUXI_JOB_TIMEOUT_SECONDS", "3600"))
     keep_result = 60
     on_startup = _worker_startup
     on_shutdown = _worker_shutdown


### PR DESCRIPTION
Fixes #884

## 变更描述
run_worker.py 的 WorkerSettings.job_timeout 由硬编码 3600 改为读环境变量 YUXI_JOB_TIMEOUT_SECONDS（默认 3600 不变）。.env.template 补充说明。超长图谱构建/深度检索不再被误取消。

## 变更类型
- [x] Bug 修复

## 测试
- [ ] 待 CI 验证