### PR TITLE
fix: web.Dockerfile 开发阶段使用 --frozen-lockfile

### DIFF
--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -10,8 +10,8 @@ RUN npm install -g pnpm@latest
 COPY ./web/package*.json ./
 COPY ./web/pnpm-lock.yaml* ./
 
-# 安装依赖
-RUN pnpm install --registry=https://registry.npmmirror.com
+# 安装依赖（--frozen-lockfile 保证 dev 与 build/CI 三处依赖与 pnpm-lock.yaml 一致，避免漂移）
+RUN pnpm install --frozen-lockfile --registry=https://registry.npmmirror.com
 
 # 复制源代码
 COPY ./web .


### PR DESCRIPTION
Fixes #886

## 变更描述
web.Dockerfile development 阶段 pnpm install 加 --frozen-lockfile，与 build 阶段一致，避免 dev 镜像依赖漂移。

## 变更类型
- [x] Bug 修复

## 测试
- [ ] 待 Docker 构建验证