### PR TITLE
fix: 将 GPL-2.0 的 python-igraph 从硬依赖移入可选依赖

### DIFF
--- a/backend/package/pyproject.toml
+++ b/backend/package/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "docling>=2.68.0",
     "docx2txt>=0.9",
     "httpx>=0.27.0",
-    "igraph>=0.11.8",
     "json-repair>=0.54.0",
     "langchain>=1.3.9",
     "langchain-community>=0.4",
@@ -84,6 +83,12 @@ dependencies = [
     "nltk>=3.8.1",
     "beautifulsoup4>=4.12.0",
 ]
+
+[project.optional-dependencies]
+# python-igraph 为 GPL-2.0 许可，不随默认安装强制携带；
+# 仅在使用 PPR 图谱排序（rank_chunks_by_ppr）时显式安装。
+# 安装：uv pip install "yuxi[graph]" 或 uv sync --extra graph
+graph = ["igraph>=0.11.8"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Fixes #864

## 变更描述
backend/package/pyproject.toml 将 igraph（GPL-2.0）从 dependencies 移入 [project.optional-dependencies] graph 组。代码中 igraph 本就是 try/except 可选导入，默认安装不再强制携带 GPL 许可包。

## 变更类型
- [x] Bug 修复

## 测试
- [ ] 待 CI 验证