### PR TITLE
fix: LangGraph SQLite checkpoint 启用 WAL 与 busy_timeout

### DIFF
--- a/backend/package/yuxi/agents/base.py
+++ b/backend/package/yuxi/agents/base.py
@@ -400,6 +400,11 @@ class BaseAgent:
             return self._async_conn
 
         conn = await aiosqlite.connect(os.path.join(self.workdir, "aio_history.db"))
+        # WAL + busy_timeout：api 与 worker 多进程会并发写同一 checkpoint 库，
+        # 默认回滚日志模式下写写/读写互斥，超时后抛 SQLITE_BUSY。WAL 让写不阻塞读、崩溃可恢复。
+        for pragma in ("PRAGMA journal_mode=WAL", "PRAGMA busy_timeout=5000", "PRAGMA synchronous=NORMAL"):
+            cursor = await conn.execute(pragma)
+            await cursor.fetchall()
         # Patch: langgraph's AsyncSqliteSaver expects is_alive() method which aiosqlite may not have
         if not hasattr(conn, "is_alive"):
             conn.is_alive = lambda: True


### PR DESCRIPTION
Fixes #875

## 变更描述
`agents/base.py::get_async_conn` 连接 SQLite checkpoint（aio_history.db）后启用：
- `PRAGMA journal_mode=WAL`：写不阻塞读、崩溃可恢复
- `PRAGMA busy_timeout=5000`：api 与 worker 多进程并发写等待 5s 而非抛 SQLITE_BUSY
- `PRAGMA synchronous=NORMAL`：性能与持久性平衡

解决 api 与 worker 双进程并发写同一 checkpoint 库时的锁冲突/静默失败。

## 变更类型
- [x] Bug 修复

## 测试
- [x] ruff check 通过
- [x] 单元测试：164 passed / 1 failed（失败项为既有的 test_summary_graph_config，与本改动无关）
- [x] WAL 模式生效验证