### PR TITLE
fix(docker): 锁定 mineru 版本为 3.4.4，避免许可证随版本漂移

### DIFF
--- a/docker/mineru.Dockerfile
+++ b/docker/mineru.Dockerfile
@@ -15,8 +15,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install mineru latest
-RUN python3 -m pip install -U 'mineru[core]>=3.0.0' -i https://mirrors.aliyun.com/pypi/simple --break-system-packages && \
+# Install mineru with pinned version.
+# MinerU 许可证随版本变化：3.0.x = AGPL-3.0；3.1.0+ = Apache-2.0 + 附加条款
+# （MAU>1 亿或月收入>$2000 万需商业许可，在线服务须标注归属）。锁版本保证构建产物许可可预期。
+RUN python3 -m pip install -U 'mineru[core]==3.4.4' -i https://mirrors.aliyun.com/pypi/simple --break-system-packages && \
     python3 -m pip cache purge
 
 # Download models and update the configuration file


### PR DESCRIPTION
## 变更描述

锁定 `docker/mineru.Dockerfile` 中的 mineru 版本为 `==3.4.4`，避免许可证随版本漂移。

**背景**：MinerU 许可证随版本变化——3.0.x 为 AGPL-3.0；3.1.0+ 改为 Apache-2.0 + 附加条款（MAU>1 亿或月收入>$2000 万需商业许可，在线服务须标注归属）。原 `'mineru[core]>=3.0.0'` 每次构建可能得到不同许可的产物，Dockerfile 声明不准确。锁版本并注释说明许可边界，保证构建产物许可可预期。

## 变更类型
- [ ] 新功能
- [x] Bug 修复
- [ ] 文档更新
- [ ] 其他

## 测试
- [ ] 已在 Docker 环境测试（docker 不可用，单行版本锁定无代码逻辑）
- [ ] 相关功能正常工作

## 说明
关联 issue：#872。改动为 1 行版本号 + 注释，无逻辑变更。

Fixes #872
