### PR TITLE
fix(mcp): catch ExceptionGroup to prevent agent crash on MCP transport errors

### DIFF
--- a/backend/package/yuxi/agents/mcp/service.py
+++ b/backend/package/yuxi/agents/mcp/service.py
@@ -340,6 +340,9 @@ async def get_mcp_tools(
                     f"{len(all_processed_tools)} tools loaded."
                 )
 
+        except ExceptionGroup as e:
+            logger.warning(f"MCP server '{server_slug}' failed with group error: {e}")
+            return []
         except Exception as e:
             logger.exception(f"Failed to load tools from MCP server '{server_slug}': {e}")
             return []

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -564,6 +564,26 @@ async def process_agent_run(ctx, run_id: str):
             logger.info(f"Run cancelled: {run_id}")
         else:
             logger.info(f"Run cancellation ignored after terminal status: {run_id}, status={transition.status}")
+    except ExceptionGroup as e:
+        await writer.flush()
+        message = str(e)
+        logger.error(f"Run failed {run_id}: {message}")
+        error_chunk = {
+            "status": "error",
+            "error_type": "worker_error",
+            "error_message": message,
+            "request_id": request_id,
+            "retryable": False,
+        }
+        await append_run_event(
+            run_id,
+            "error",
+            {"chunk": error_chunk, "retryable": False},
+            thread_id=thread_id,
+        )
+        await mark_run_terminal(run_id, "failed", error_type="worker_error", error_message=message)
+        await _append_end_event(run_id, "failed", thread_id=thread_id, payload={"chunk": error_chunk})
+        return
     except Exception as e:
         await writer.flush()
         if _is_retryable_exception(e):


### PR DESCRIPTION
## 问题

单个 MCP Server 出错（如返回 401、连接超时、连接拒绝）会导致整个智能体崩溃，报错：

```
Error streaming messages: unhandled errors in a TaskGroup (1 sub-exception)
```

## 根因

`langchain_mcp_adapters` 的 `MultiServerMCPClient` 内部使用 `anyio.TaskGroup` 管理会话。当 transport 层报错时，TaskGroup 抛出 **`ExceptionGroup`**。

关键点：**`ExceptionGroup` 是 `BaseException` 的直接子类，不是 `Exception` 的子类**（Python 3.11+ 引入）。因此现有代码里的 `except Exception as e:` 捕获不到它，异常直接穿透，最终变成 unhandled error 导致整个智能体崩溃。

这就是为什么报错信息是 `unhandled errors in a TaskGroup` —— 因为没有任何 `except Exception` 能抓到它。

## 改动（两处，各加一个 `except ExceptionGroup`）

### 1. `backend/package/yuxi/agents/mcp/service.py` — `get_mcp_tools`

单个 MCP server 加载工具失败时，只返回空列表 `[]`，移除该 server 的工具，不影响其他 MCP server：

```python
        except ExceptionGroup as e:
            logger.warning(f"MCP server '{server_slug}' failed with group error: {e}")
            return []
        except Exception as e:
            logger.exception(f"Failed to load tools from MCP server '{server_slug}': {e}")
            return []
```

### 2. `backend/package/yuxi/services/run_worker.py` — `process_agent_run`

agent 运行过程中 MCP 出错时，做完整清理（flush writer、标记 run failed、追加 end 事件、return），否则对话会卡住无反馈：

```python
    except ExceptionGroup as e:
        await writer.flush()
        message = str(e)
        logger.error(f"Run failed {run_id}: {message}")
        error_chunk = {
            "status": "error",
            "error_type": "worker_error",
            "error_message": message,
            "request_id": request_id,
            "retryable": False,
        }
        await append_run_event(
            run_id, "error",
            {"chunk": error_chunk, "retryable": False},
            thread_id=thread_id,
        )
        await mark_run_terminal(run_id, "failed", error_type="worker_error", error_message=message)
        await _append_end_event(run_id, "failed", thread_id=thread_id, payload={"chunk": error_chunk})
        return
    except Exception as e:
        ...
```

## 说明

- `except ExceptionGroup` 必须写在 `except Exception` 之前（虽然两者是 `BaseException` 的并列子类，但按书写顺序匹配，先写更具体的语义更清晰）。
- 两处改动均为最小化 try/except 增强，不改变现有业务逻辑。
- 修改后，单个 MCP 挂了只会移除它的工具或标记本次 run 失败并通知用户，不会再让整个智能体 unhandled 崩溃。