### PR TITLE
feat: 完善 Agent Token 用量统计

### DIFF
--- a/backend/package/yuxi/agents/middlewares/token_usage.py
+++ b/backend/package/yuxi/agents/middlewares/token_usage.py
@@ -256,9 +256,7 @@ def _recompute_aggregate_totals(aggregate: dict[str, Any]) -> None:
     """根据当前 models 重算聚合级计数和 total。"""
     models = aggregate["models"]
     aggregate["model_call_count"] = sum(
-        _safe_int(bucket.get("model_call_count")) or 0
-        for bucket in models.values()
-        if isinstance(bucket, Mapping)
+        _safe_int(bucket.get("model_call_count")) or 0 for bucket in models.values() if isinstance(bucket, Mapping)
     )
     aggregate["usage_reported_call_count"] = sum(
         _safe_int(bucket.get("usage_reported_call_count")) or 0

--- a/backend/package/yuxi/agents/middlewares/token_usage.py
+++ b/backend/package/yuxi/agents/middlewares/token_usage.py
@@ -123,6 +123,7 @@ def _is_tool_message(message: AnyMessage) -> bool:
 
 
 def _ai_message_from_response(response: ModelResponse) -> AIMessage | None:
+    """从模型响应结果中取最后一条 AIMessage。"""
     for message in reversed(response.result):
         if isinstance(message, AIMessage):
             return message
@@ -130,6 +131,7 @@ def _ai_message_from_response(response: ModelResponse) -> AIMessage | None:
 
 
 def _model_usage_from_response(response: ModelResponse) -> dict[str, Any] | None:
+    """提取响应中 AIMessage 携带的原始 usage_metadata。"""
     message = _ai_message_from_response(response)
     usage = getattr(message, "usage_metadata", None) if message else None
     return dict(usage) if isinstance(usage, Mapping) else None
@@ -161,6 +163,7 @@ def _usage_for_accumulation(usage: Mapping[str, Any] | None) -> UsageMetadata | 
 
 
 def _model_identity(request: ModelRequest, response: ModelResponse) -> dict[str, str]:
+    """依次从模型元数据、运行时上下文配置的 model spec、model_cache 和响应元数据解析模型身份信息。"""
     model_metadata = getattr(request.model, "metadata", None) or {}
     runtime_context = getattr(request.runtime, "context", None)
     configured_spec = getattr(runtime_context, "model", None)
@@ -206,11 +209,13 @@ def _model_identity(request: ModelRequest, response: ModelResponse) -> dict[str,
 
 
 def _usage_input_tokens(usage: Mapping[str, Any] | None) -> int:
+    """读取 usage 中的 input_tokens，缺失或非法时返回 0。"""
     value = usage.get("input_tokens") if usage else None
     return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 def _cache_read_tokens(usage: Mapping[str, Any] | None) -> int | None:
+    """按优先级从 input_token_details 中读取缓存命中 token 数，未观测到缓存字段时返回 None。"""
     details = usage.get("input_token_details") if usage else None
     if not isinstance(details, Mapping):
         return None
@@ -223,10 +228,12 @@ def _cache_read_tokens(usage: Mapping[str, Any] | None) -> int | None:
 
 
 def _ratio(numerator: int, denominator: int) -> float | None:
+    """计算比例，分母为 0 时返回 None 而非抛出除零异常。"""
     return round(numerator / denominator, 4) if denominator > 0 else None
 
 
 def _empty_aggregate() -> dict[str, Any]:
+    """构造一个空的 v2 聚合结构，作为 Run/Thread 用量的初始状态。"""
     return {
         "schema_version": 2,
         "model_call_count": 0,
@@ -239,6 +246,7 @@ def _empty_aggregate() -> dict[str, Any]:
 
 
 def _aggregate_from_state(value: Any) -> dict[str, Any]:
+    """校验并规整从 state 读取的聚合结构，schema_version 不匹配时回退为空聚合。"""
     if not isinstance(value, Mapping) or value.get("schema_version") != 2:
         return _empty_aggregate()
     models = value.get("models")
@@ -309,6 +317,7 @@ def _without_blacklisted_providers(aggregate: Mapping[str, Any]) -> dict[str, An
 
 
 def _bucket_key(identity: Mapping[str, str], model: Any) -> tuple[str, str]:
+    """按优先级选取用量分桶 key：配置的 model spec > 响应携带的 model id > 适配器兜底标识。"""
     configured_spec = identity.get("configured_model_spec")
     if configured_spec:
         return configured_spec, "configured_metadata"
@@ -328,6 +337,7 @@ def _add_call_to_aggregate(
     identity: Mapping[str, str],
     usage: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
+    """把一次模型调用的 usage 累加进指定分桶，同时更新缓存命中统计和聚合总计。"""
     result = _aggregate_from_state(aggregate)
     models = result["models"]
     previous_bucket = models.get(bucket_key)

--- a/backend/package/yuxi/agents/middlewares/token_usage.py
+++ b/backend/package/yuxi/agents/middlewares/token_usage.py
@@ -14,8 +14,41 @@ from langchain.agents.middleware.types import (
     ModelResponse,
 )
 from langchain_core.messages import AIMessage, AnyMessage
+from langchain_core.messages.ai import UsageMetadata, add_usage
 from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.types import Command
+
+from yuxi.models.providers.cache import model_cache
+
+TOKEN_USAGE_PROVIDER_BLACKLIST = frozenset({"siliconflow-cn", "siliconflow"})
+ZERO_TOTAL = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+TOKEN_USAGE_CONTEXT_FIELDS = frozenset(
+    {
+        "state_message_count",
+        "state_message_count_before_call",
+        "state_messages_tokens",
+        "state_messages_tokens_before_call",
+        "llm_message_count",
+        "llm_messages_tokens",
+        "llm_content_message_count",
+        "llm_content_message_tokens",
+        "llm_tool_message_count",
+        "llm_tool_message_tokens",
+        "llm_input_tokens",
+        "system_tokens",
+        "tools_tokens",
+        "tool_count",
+        "context_window",
+        "context_usage_ratio",
+        "remaining_context_tokens",
+        "summary_active",
+        "summary_message_tokens",
+        "summary_trigger_tokens",
+        "counter",
+        "estimate",
+        "measured_at",
+    }
+)
 
 
 class TokenUsagePayload(TypedDict, total=False):
@@ -41,7 +74,10 @@ class TokenUsagePayload(TypedDict, total=False):
     summary_active: bool
     summary_message_tokens: int
     summary_trigger_tokens: int | None
-    model_usage: dict[str, int]
+    current_run_id: str
+    latest: dict[str, Any] | None
+    run: dict[str, Any]
+    thread: dict[str, Any]
     counter: str
     estimate: bool
     measured_at: str
@@ -86,15 +122,244 @@ def _is_tool_message(message: AnyMessage) -> bool:
     return getattr(message, "type", None) == "tool" or getattr(message, "role", None) == "tool"
 
 
-def _model_usage_from_response(response: ModelResponse) -> dict[str, int]:
+def _ai_message_from_response(response: ModelResponse) -> AIMessage | None:
     for message in reversed(response.result):
-        if not isinstance(message, AIMessage):
+        if isinstance(message, AIMessage):
+            return message
+    return None
+
+
+def _model_usage_from_response(response: ModelResponse) -> dict[str, Any] | None:
+    message = _ai_message_from_response(response)
+    usage = getattr(message, "usage_metadata", None) if message else None
+    return dict(usage) if isinstance(usage, Mapping) else None
+
+
+def _usage_for_accumulation(usage: Mapping[str, Any] | None) -> UsageMetadata | None:
+    """保留可累计的数值 token 字段，忽略 Provider 的非数值扩展元数据。"""
+    if not usage:
+        return None
+
+    normalized: dict[str, Any] = {}
+    for key, value in usage.items():
+        if isinstance(value, int) and not isinstance(value, bool):
+            normalized[str(key)] = value
             continue
-        usage = getattr(message, "usage_metadata", None)
-        if not isinstance(usage, Mapping):
+        if isinstance(value, Mapping):
+            details = {
+                str(detail_key): detail_value
+                for detail_key, detail_value in value.items()
+                if isinstance(detail_value, int) and not isinstance(detail_value, bool)
+            }
+            if details:
+                normalized[str(key)] = details
+
+    required_keys = ("input_tokens", "output_tokens", "total_tokens")
+    if not all(isinstance(normalized.get(key), int) for key in required_keys):
+        return None
+    return normalized  # type: ignore[return-value]
+
+
+def _model_identity(request: ModelRequest, response: ModelResponse) -> dict[str, str]:
+    model_metadata = getattr(request.model, "metadata", None) or {}
+    runtime_context = getattr(request.runtime, "context", None)
+    configured_spec = getattr(runtime_context, "model", None)
+    configured_spec = configured_spec.strip() if isinstance(configured_spec, str) else ""
+
+    identity: dict[str, str] = {}
+    for key, meta_key in (
+        ("provider_id", "yuxi_provider_id"),
+        ("provider_type", "yuxi_provider_type"),
+        ("configured_model_id", "yuxi_model_id"),
+        ("configured_model_spec", "yuxi_model_spec"),
+    ):
+        value = model_metadata.get(meta_key)
+        if isinstance(value, str) and value:
+            identity[key] = value
+
+    if not identity and configured_spec:
+        model_info = model_cache.get_model_info(configured_spec)
+        if model_info:
+            identity = {
+                "provider_id": model_info.provider_id,
+                "provider_type": model_info.provider_type,
+                "configured_model_id": model_info.model_id,
+                "configured_model_spec": model_info.spec,
+            }
+        else:
+            identity["configured_model_spec"] = configured_spec
+    elif configured_spec:
+        identity["configured_model_spec"] = configured_spec
+
+    message = _ai_message_from_response(response)
+    response_metadata = getattr(message, "response_metadata", None) if message else None
+    if isinstance(response_metadata, Mapping):
+        response_model_id = response_metadata.get("model_name") or response_metadata.get("model")
+        if isinstance(response_model_id, str) and response_model_id:
+            identity["response_model_id"] = response_model_id
+        if "provider_type" not in identity:
+            response_provider = response_metadata.get("model_provider")
+            if isinstance(response_provider, str) and response_provider:
+                identity["provider_type"] = response_provider
+
+    return identity
+
+
+def _usage_input_tokens(usage: Mapping[str, Any] | None) -> int:
+    value = usage.get("input_tokens") if usage else None
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _cache_read_tokens(usage: Mapping[str, Any] | None) -> int | None:
+    details = usage.get("input_token_details") if usage else None
+    if not isinstance(details, Mapping):
+        return None
+    for key in ("cache_read", "priority_cache_read", "flex_cache_read"):
+        if key not in details:
             continue
-        return {str(key): value for key, value in usage.items() if isinstance(value, int)}
-    return {}
+        value = details.get(key)
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+    return None
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    return round(numerator / denominator, 4) if denominator > 0 else None
+
+
+def _empty_aggregate() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "model_call_count": 0,
+        "usage_reported_call_count": 0,
+        "models": {},
+        "total": dict(ZERO_TOTAL),
+    }
+
+
+def _aggregate_from_state(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or value.get("schema_version") != 2:
+        return _empty_aggregate()
+    models = value.get("models")
+    total = value.get("total")
+    return {
+        "schema_version": 2,
+        "model_call_count": _safe_int(value.get("model_call_count")) or 0,
+        "usage_reported_call_count": _safe_int(value.get("usage_reported_call_count")) or 0,
+        "models": {str(key): dict(bucket) for key, bucket in models.items() if isinstance(bucket, Mapping)}
+        if isinstance(models, Mapping)
+        else {},
+        "total": dict(total) if isinstance(total, Mapping) else dict(ZERO_TOTAL),
+    }
+
+
+def _recompute_aggregate_totals(aggregate: dict[str, Any]) -> None:
+    """根据当前 models 重算聚合级计数和 total。"""
+    models = aggregate["models"]
+    aggregate["model_call_count"] = sum(
+        _safe_int(bucket.get("model_call_count")) or 0
+        for bucket in models.values()
+        if isinstance(bucket, Mapping)
+    )
+    aggregate["usage_reported_call_count"] = sum(
+        _safe_int(bucket.get("usage_reported_call_count")) or 0
+        for bucket in models.values()
+        if isinstance(bucket, Mapping)
+    )
+    total = dict(ZERO_TOTAL)
+    for bucket in models.values():
+        if not isinstance(bucket, Mapping):
+            continue
+        bucket_usage = bucket.get("usage")
+        if not isinstance(bucket_usage, Mapping):
+            continue
+        for key in total:
+            total[key] += _safe_int(bucket_usage.get(key)) or 0
+    aggregate["total"] = total
+
+
+def _without_blacklisted_providers(aggregate: Mapping[str, Any]) -> dict[str, Any]:
+    """移除历史 checkpoint 中已禁用 Provider 的错误用量桶。"""
+    result = _aggregate_from_state(aggregate)
+    result["models"] = {
+        key: bucket
+        for key, bucket in result["models"].items()
+        if not (
+            isinstance(bucket.get("model"), Mapping)
+            and bucket["model"].get("provider_id") in TOKEN_USAGE_PROVIDER_BLACKLIST
+        )
+    }
+    _recompute_aggregate_totals(result)
+    return result
+
+
+def _bucket_key(identity: Mapping[str, str], model: Any) -> tuple[str, str]:
+    configured_spec = identity.get("configured_model_spec")
+    if configured_spec:
+        return configured_spec, "configured_metadata"
+    response_model_id = identity.get("response_model_id")
+    provider_type = identity.get("provider_type") or "unknown"
+    if response_model_id:
+        return f"response:{provider_type}:{response_model_id}", "response_metadata"
+    model_id = getattr(model, "model_name", None) or getattr(model, "model", None) or "unknown"
+    return f"unattributed:{model.__class__.__name__}:{model_id}", "adapter_fallback"
+
+
+def _add_call_to_aggregate(
+    aggregate: Mapping[str, Any],
+    *,
+    bucket_key: str,
+    identity_source: str,
+    identity: Mapping[str, str],
+    usage: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    result = _aggregate_from_state(aggregate)
+    models = result["models"]
+    previous_bucket = models.get(bucket_key)
+    previous_bucket = dict(previous_bucket) if isinstance(previous_bucket, Mapping) else {}
+    usage_increment = _usage_for_accumulation(usage)
+    previous_usage = previous_bucket.get("usage")
+    previous_usage = _usage_for_accumulation(previous_usage) if isinstance(previous_usage, Mapping) else None
+    cumulative_usage = add_usage(previous_usage, usage_increment) if usage_increment else previous_usage
+
+    model_identity = previous_bucket.get("model")
+    model_identity = dict(model_identity) if isinstance(model_identity, Mapping) else {}
+    model_identity.update({key: value for key, value in identity.items() if key != "response_model_id"})
+    model_identity["identity_source"] = identity_source
+    response_model_ids = model_identity.get("response_model_ids")
+    response_model_ids = list(response_model_ids) if isinstance(response_model_ids, list) else []
+    response_model_id = identity.get("response_model_id")
+    if response_model_id and response_model_id not in response_model_ids:
+        response_model_ids.append(response_model_id)
+    model_identity["response_model_ids"] = response_model_ids
+
+    cache_read = _cache_read_tokens(usage)
+    cache_observed = cache_read is not None
+    cache_observed_calls = (_safe_int(previous_bucket.get("cache_observed_call_count")) or 0) + int(cache_observed)
+    cache_hit_calls = (_safe_int(previous_bucket.get("cache_hit_call_count")) or 0) + int(
+        cache_read is not None and cache_read > 0
+    )
+    observed_input = (_safe_int(previous_bucket.get("cache_observed_input_tokens")) or 0) + (
+        _usage_input_tokens(usage) if cache_observed else 0
+    )
+    cache_read_input = (_safe_int(previous_bucket.get("cache_read_input_tokens")) or 0) + (cache_read or 0)
+
+    models[bucket_key] = {
+        "model": model_identity,
+        "usage": cumulative_usage or {},
+        "model_call_count": (_safe_int(previous_bucket.get("model_call_count")) or 0) + 1,
+        "usage_reported_call_count": (_safe_int(previous_bucket.get("usage_reported_call_count")) or 0)
+        + int(usage_increment is not None),
+        "cache_observed_call_count": cache_observed_calls,
+        "cache_hit_call_count": cache_hit_calls,
+        "cache_observed_input_tokens": observed_input,
+        "cache_read_input_tokens": cache_read_input,
+        "uncached_input_tokens": max(observed_input - cache_read_input, 0) if cache_observed_calls else None,
+        "cache_hit_ratio": _ratio(cache_read_input, observed_input),
+        "cache_request_hit_ratio": _ratio(cache_hit_calls, cache_observed_calls),
+    }
+
+    _recompute_aggregate_totals(result)
+    return result
 
 
 class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
@@ -111,6 +376,37 @@ class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
         if tools is not None:
             return int(self.token_counter(message_list, tools=tools))
         return int(self.token_counter(message_list))
+
+    def before_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
+        """在 Run 入口重置 Run 级用量，同时保留 v2 线程累计。"""
+        run_id = str(getattr(runtime.context, "run_id", None) or "")
+        previous = state.get("token_usage")
+        previous = previous if isinstance(previous, Mapping) else {}
+        same_run = previous.get("current_run_id") == run_id and isinstance(previous.get("run"), Mapping)
+        context_fields = {key: previous[key] for key in TOKEN_USAGE_CONTEXT_FIELDS if key in previous}
+        latest = previous.get("latest") if same_run else None
+        if isinstance(latest, Mapping):
+            latest_model = latest.get("model")
+            latest_bucket_key = latest.get("bucket_key")
+            latest_provider_id = latest_model.get("provider_id") if isinstance(latest_model, Mapping) else None
+            if latest_provider_id in TOKEN_USAGE_PROVIDER_BLACKLIST or (
+                isinstance(latest_bucket_key, str)
+                and latest_bucket_key.split(":", 1)[0] in TOKEN_USAGE_PROVIDER_BLACKLIST
+            ):
+                latest = None
+        return {
+            "token_usage": {
+                **context_fields,
+                "current_run_id": run_id,
+                "latest": latest,
+                "run": _without_blacklisted_providers(previous.get("run")) if same_run else _empty_aggregate(),
+                "thread": _without_blacklisted_providers(previous.get("thread")),
+            }
+        }
+
+    async def abefore_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
+        """异步入口复用同步 Run 初始化逻辑。"""
+        return self.before_agent(state, runtime)
 
     def _build_snapshot(self, request: ModelRequest, response: ModelResponse) -> TokenUsagePayload:
         state_messages = list(request.state.get("messages") or [])
@@ -140,6 +436,48 @@ class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
             message for message in llm_messages if not _is_tool_message(message) and not _is_summary_message(message)
         ]
         summary_trigger_tokens = _summary_trigger_tokens(getattr(request.runtime, "context", None))
+        previous_snapshot = request.state.get("token_usage")
+        previous_snapshot = previous_snapshot if isinstance(previous_snapshot, Mapping) else {}
+        model_usage = _model_usage_from_response(response)
+        identity = _model_identity(request, response)
+        runtime_context = getattr(request.runtime, "context", None)
+        run_id = str(getattr(runtime_context, "run_id", None) or "")
+        previous_run = previous_snapshot.get("run") if previous_snapshot.get("current_run_id") == run_id else None
+        measured_at = datetime.now(UTC).isoformat()
+        latest_usage = None
+        run_usage = _without_blacklisted_providers(
+            previous_run if isinstance(previous_run, Mapping) else _empty_aggregate()
+        )
+        thread_usage = _without_blacklisted_providers(previous_snapshot.get("thread"))
+
+        if identity.get("provider_id") not in TOKEN_USAGE_PROVIDER_BLACKLIST:
+            bucket_key, identity_source = _bucket_key(identity, request.model)
+            run_usage = _add_call_to_aggregate(
+                run_usage,
+                bucket_key=bucket_key,
+                identity_source=identity_source,
+                identity=identity,
+                usage=model_usage,
+            )
+            thread_usage = _add_call_to_aggregate(
+                thread_usage,
+                bucket_key=bucket_key,
+                identity_source=identity_source,
+                identity=identity,
+                usage=model_usage,
+            )
+            cache_read_tokens = _cache_read_tokens(model_usage)
+            input_tokens = _usage_input_tokens(model_usage)
+            latest_usage = {
+                "bucket_key": bucket_key,
+                "model": identity,
+                "usage": model_usage or {},
+                "uncached_input_tokens": (
+                    max(input_tokens - cache_read_tokens, 0) if cache_read_tokens is not None else None
+                ),
+                "cache_hit_ratio": (_ratio(cache_read_tokens, input_tokens) if cache_read_tokens is not None else None),
+                "measured_at": measured_at,
+            }
 
         return {
             "state_message_count": len(next_state_messages),
@@ -162,10 +500,13 @@ class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
             "summary_active": summary_message is not None,
             "summary_message_tokens": self._count_tokens([summary_message]) if summary_message else 0,
             "summary_trigger_tokens": summary_trigger_tokens,
-            "model_usage": _model_usage_from_response(response),
+            "current_run_id": run_id,
+            "latest": latest_usage,
+            "run": run_usage,
+            "thread": thread_usage,
             "counter": "langchain.count_tokens_approximately",
             "estimate": True,
-            "measured_at": datetime.now(UTC).isoformat(),
+            "measured_at": measured_at,
         }
 
     def wrap_model_call(

--- a/backend/package/yuxi/agents/middlewares/token_usage.py
+++ b/backend/package/yuxi/agents/middlewares/token_usage.py
@@ -231,6 +231,8 @@ def _empty_aggregate() -> dict[str, Any]:
         "schema_version": 2,
         "model_call_count": 0,
         "usage_reported_call_count": 0,
+        "usage_unavailable_call_count": 0,
+        "complete": False,
         "models": {},
         "total": dict(ZERO_TOTAL),
     }
@@ -245,6 +247,8 @@ def _aggregate_from_state(value: Any) -> dict[str, Any]:
         "schema_version": 2,
         "model_call_count": _safe_int(value.get("model_call_count")) or 0,
         "usage_reported_call_count": _safe_int(value.get("usage_reported_call_count")) or 0,
+        "usage_unavailable_call_count": _safe_int(value.get("usage_unavailable_call_count")) or 0,
+        "complete": value.get("complete") is True,
         "models": {str(key): dict(bucket) for key, bucket in models.items() if isinstance(bucket, Mapping)}
         if isinstance(models, Mapping)
         else {},
@@ -255,13 +259,19 @@ def _aggregate_from_state(value: Any) -> dict[str, Any]:
 def _recompute_aggregate_totals(aggregate: dict[str, Any]) -> None:
     """根据当前 models 重算聚合级计数和 total。"""
     models = aggregate["models"]
-    aggregate["model_call_count"] = sum(
+    model_call_count = sum(
         _safe_int(bucket.get("model_call_count")) or 0 for bucket in models.values() if isinstance(bucket, Mapping)
     )
-    aggregate["usage_reported_call_count"] = sum(
+    usage_reported_call_count = sum(
         _safe_int(bucket.get("usage_reported_call_count")) or 0
         for bucket in models.values()
         if isinstance(bucket, Mapping)
+    )
+    usage_unavailable_call_count = _safe_int(aggregate.get("usage_unavailable_call_count")) or 0
+    aggregate["model_call_count"] = model_call_count + usage_unavailable_call_count
+    aggregate["usage_reported_call_count"] = usage_reported_call_count
+    aggregate["complete"] = aggregate["model_call_count"] > 0 and (
+        usage_reported_call_count == aggregate["model_call_count"]
     )
     total = dict(ZERO_TOTAL)
     for bucket in models.values():
@@ -273,6 +283,14 @@ def _recompute_aggregate_totals(aggregate: dict[str, Any]) -> None:
         for key in total:
             total[key] += _safe_int(bucket_usage.get(key)) or 0
     aggregate["total"] = total
+
+
+def _add_unavailable_call(aggregate: Mapping[str, Any]) -> dict[str, Any]:
+    """记录一次无法获得可信 Provider usage 的模型调用。"""
+    result = _aggregate_from_state(aggregate)
+    result["usage_unavailable_call_count"] += 1
+    _recompute_aggregate_totals(result)
+    return result
 
 
 def _without_blacklisted_providers(aggregate: Mapping[str, Any]) -> dict[str, Any]:
@@ -476,6 +494,9 @@ class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
                 "cache_hit_ratio": (_ratio(cache_read_tokens, input_tokens) if cache_read_tokens is not None else None),
                 "measured_at": measured_at,
             }
+        else:
+            run_usage = _add_unavailable_call(run_usage)
+            thread_usage = _add_unavailable_call(thread_usage)
 
         return {
             "state_message_count": len(next_state_messages),

--- a/backend/package/yuxi/agents/middlewares/token_usage.py
+++ b/backend/package/yuxi/agents/middlewares/token_usage.py
@@ -1,4 +1,9 @@
-"""Token usage observation middleware for Yuxi agents."""
+"""Yuxi Agent 的 Token 用量观测中间件。
+
+在每次主模型调用后估算近似上下文占用，并持久化 Provider 返回的实际
+usage_metadata，按配置模型分桶累计到 Run 与 Thread 两级；快照写入
+LangGraph state 供状态面板读取，便于展示与核对真实账单。
+"""
 
 from __future__ import annotations
 
@@ -52,7 +57,7 @@ TOKEN_USAGE_CONTEXT_FIELDS = frozenset(
 
 
 class TokenUsagePayload(TypedDict, total=False):
-    """Serializable token usage snapshot stored in LangGraph state."""
+    """可序列化的 Token 用量快照，存入 LangGraph state。"""
 
     state_message_count: int
     state_message_count_before_call: int
@@ -84,146 +89,199 @@ class TokenUsagePayload(TypedDict, total=False):
 
 
 class TokenUsageState(AgentState):
-    """Agent state extension with the latest token usage snapshot."""
+    """扩展 Agent state，携带最新的 Token 用量快照。"""
 
     token_usage: NotRequired[TokenUsagePayload]
 
 
+class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
+    """观测主模型调用并记录近似上下文与实际 Token 用量。
+
+    ``wrap_model_call`` 在每次模型调用后构建用量快照写入 state；快照同时
+    保留上下文估算字段（``TOKEN_USAGE_CONTEXT_FIELDS``）与按模型分桶的
+    Run/Thread 累计聚合。``before_agent`` 在 Run 入口重置 Run 级累计，
+    并剔除已禁用 Provider 的历史用量桶。
+    """
+
+    state_schema = TokenUsageState
+
+    def __init__(self, token_counter=count_tokens_approximately) -> None:
+        super().__init__()
+        self.token_counter = token_counter
+
+    def before_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
+        """在 Run 入口重置 Run 级用量，同时保留 v2 线程累计。"""
+        run_id = str(getattr(runtime.context, "run_id", None) or "")
+        previous = state.get("token_usage")
+        previous = previous if isinstance(previous, Mapping) else {}
+        same_run = previous.get("current_run_id") == run_id and isinstance(previous.get("run"), Mapping)
+        context_fields = {key: previous[key] for key in TOKEN_USAGE_CONTEXT_FIELDS if key in previous}
+        latest = previous.get("latest") if same_run else None
+        if isinstance(latest, Mapping):
+            latest_model = latest.get("model")
+            latest_bucket_key = latest.get("bucket_key")
+            latest_provider_id = latest_model.get("provider_id") if isinstance(latest_model, Mapping) else None
+            if latest_provider_id in TOKEN_USAGE_PROVIDER_BLACKLIST or (
+                isinstance(latest_bucket_key, str)
+                and latest_bucket_key.split(":", 1)[0] in TOKEN_USAGE_PROVIDER_BLACKLIST
+            ):
+                latest = None
+        return {
+            "token_usage": {
+                **context_fields,
+                "current_run_id": run_id,
+                "latest": latest,
+                "run": _without_blacklisted_providers(previous.get("run")) if same_run else _empty_aggregate(),
+                "thread": _without_blacklisted_providers(previous.get("thread")),
+            }
+        }
+
+    async def abefore_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
+        """异步入口复用同步 Run 初始化逻辑。"""
+        return self.before_agent(state, runtime)
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ExtendedModelResponse:
+        response = handler(request)
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"token_usage": self._build_snapshot(request, response)}),
+        )
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ExtendedModelResponse:
+        response = await handler(request)
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"token_usage": self._build_snapshot(request, response)}),
+        )
+
+    def _build_snapshot(self, request: ModelRequest, response: ModelResponse) -> TokenUsagePayload:
+        """根据单次模型请求与响应构建完整用量快照。"""
+        state_messages = list(request.state.get("messages") or [])
+        llm_messages = list(request.messages or [])
+        system_messages = [request.system_message] if request.system_message is not None else []
+        tools = list(request.tools or [])
+        response_messages = list(response.result or [])
+
+        state_tokens_before_call = self._count_tokens(state_messages)
+        next_state_messages = [*state_messages, *response_messages]
+        state_messages_tokens = self._count_tokens(next_state_messages)
+        llm_messages_tokens = self._count_tokens(llm_messages)
+        system_tokens = self._count_tokens(system_messages)
+        tools_tokens = self._count_tokens([], tools=tools) if tools else 0
+        llm_input_tokens = self._count_tokens([*system_messages, *llm_messages], tools=tools)
+
+        context_window = _model_context_window(request.model)
+        context_usage_ratio = None
+        remaining_context_tokens = None
+        if context_window:
+            context_usage_ratio = min(1.0, round(llm_input_tokens / context_window, 4))
+            remaining_context_tokens = max(context_window - llm_input_tokens, 0)
+
+        summary_message = llm_messages[0] if llm_messages and _is_summary_message(llm_messages[0]) else None
+        llm_tool_messages = [message for message in llm_messages if _is_tool_message(message)]
+        llm_content_messages = [
+            message for message in llm_messages if not _is_tool_message(message) and not _is_summary_message(message)
+        ]
+        summary_trigger_tokens = _summary_trigger_tokens(getattr(request.runtime, "context", None))
+        previous_snapshot = request.state.get("token_usage")
+        previous_snapshot = previous_snapshot if isinstance(previous_snapshot, Mapping) else {}
+        model_usage = _model_usage_from_response(response)
+        identity = _model_identity(request, response)
+        runtime_context = getattr(request.runtime, "context", None)
+        run_id = str(getattr(runtime_context, "run_id", None) or "")
+        previous_run = previous_snapshot.get("run") if previous_snapshot.get("current_run_id") == run_id else None
+        measured_at = datetime.now(UTC).isoformat()
+        latest_usage = None
+        run_usage = _without_blacklisted_providers(
+            previous_run if isinstance(previous_run, Mapping) else _empty_aggregate()
+        )
+        thread_usage = _without_blacklisted_providers(previous_snapshot.get("thread"))
+
+        if identity.get("provider_id") not in TOKEN_USAGE_PROVIDER_BLACKLIST:
+            bucket_key, identity_source = _bucket_key(identity, request.model)
+            run_usage = _add_call_to_aggregate(
+                run_usage,
+                bucket_key=bucket_key,
+                identity_source=identity_source,
+                identity=identity,
+                usage=model_usage,
+            )
+            thread_usage = _add_call_to_aggregate(
+                thread_usage,
+                bucket_key=bucket_key,
+                identity_source=identity_source,
+                identity=identity,
+                usage=model_usage,
+            )
+            cache_read_tokens = _cache_read_tokens(model_usage)
+            input_tokens = _usage_input_tokens(model_usage)
+            latest_usage = {
+                "bucket_key": bucket_key,
+                "model": identity,
+                "usage": model_usage or {},
+                "uncached_input_tokens": (
+                    max(input_tokens - cache_read_tokens, 0) if cache_read_tokens is not None else None
+                ),
+                "cache_hit_ratio": (_ratio(cache_read_tokens, input_tokens) if cache_read_tokens is not None else None),
+                "measured_at": measured_at,
+            }
+        else:
+            run_usage = _add_unavailable_call(run_usage)
+            thread_usage = _add_unavailable_call(thread_usage)
+
+        return {
+            "state_message_count": len(next_state_messages),
+            "state_message_count_before_call": len(state_messages),
+            "state_messages_tokens": state_messages_tokens,
+            "state_messages_tokens_before_call": state_tokens_before_call,
+            "llm_message_count": len(llm_messages),
+            "llm_messages_tokens": llm_messages_tokens,
+            "llm_content_message_count": len(llm_content_messages),
+            "llm_content_message_tokens": self._count_tokens(llm_content_messages),
+            "llm_tool_message_count": len(llm_tool_messages),
+            "llm_tool_message_tokens": self._count_tokens(llm_tool_messages),
+            "llm_input_tokens": llm_input_tokens,
+            "system_tokens": system_tokens,
+            "tools_tokens": tools_tokens,
+            "tool_count": len(tools),
+            "context_window": context_window,
+            "context_usage_ratio": context_usage_ratio,
+            "remaining_context_tokens": remaining_context_tokens,
+            "summary_active": summary_message is not None,
+            "summary_message_tokens": self._count_tokens([summary_message]) if summary_message else 0,
+            "summary_trigger_tokens": summary_trigger_tokens,
+            "current_run_id": run_id,
+            "latest": latest_usage,
+            "run": run_usage,
+            "thread": thread_usage,
+            "counter": "langchain.count_tokens_approximately",
+            "estimate": True,
+            "measured_at": measured_at,
+        }
+
+    def _count_tokens(self, messages: Iterable[Any], *, tools: list[Any] | None = None) -> int:
+        message_list = list(messages)
+        if tools is not None:
+            return int(self.token_counter(message_list, tools=tools))
+        return int(self.token_counter(message_list))
+
+
 def _safe_int(value: Any) -> int | None:
+    """将数值安全转换为 int，bool 与非整数值返回 None。"""
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
         return value
     if isinstance(value, float) and value.is_integer():
         return int(value)
-    return None
-
-
-def _model_context_window(model: Any) -> int | None:
-    profile = getattr(model, "profile", None)
-    if not isinstance(profile, Mapping):
-        return None
-    max_input_tokens = profile.get("max_input_tokens")
-    return max_input_tokens if isinstance(max_input_tokens, int) and max_input_tokens > 0 else None
-
-
-def _summary_trigger_tokens(runtime_context: Any) -> int | None:
-    threshold = _safe_int(getattr(runtime_context, "summary_threshold", None))
-    if threshold is None or threshold <= 0:
-        return None
-    return threshold * 1024
-
-
-def _is_summary_message(message: AnyMessage) -> bool:
-    return getattr(message, "additional_kwargs", {}).get("lc_source") == "summarization"
-
-
-def _is_tool_message(message: AnyMessage) -> bool:
-    return getattr(message, "type", None) == "tool" or getattr(message, "role", None) == "tool"
-
-
-def _ai_message_from_response(response: ModelResponse) -> AIMessage | None:
-    """从模型响应结果中取最后一条 AIMessage。"""
-    for message in reversed(response.result):
-        if isinstance(message, AIMessage):
-            return message
-    return None
-
-
-def _model_usage_from_response(response: ModelResponse) -> dict[str, Any] | None:
-    """提取响应中 AIMessage 携带的原始 usage_metadata。"""
-    message = _ai_message_from_response(response)
-    usage = getattr(message, "usage_metadata", None) if message else None
-    return dict(usage) if isinstance(usage, Mapping) else None
-
-
-def _usage_for_accumulation(usage: Mapping[str, Any] | None) -> UsageMetadata | None:
-    """保留可累计的数值 token 字段，忽略 Provider 的非数值扩展元数据。"""
-    if not usage:
-        return None
-
-    normalized: dict[str, Any] = {}
-    for key, value in usage.items():
-        if isinstance(value, int) and not isinstance(value, bool):
-            normalized[str(key)] = value
-            continue
-        if isinstance(value, Mapping):
-            details = {
-                str(detail_key): detail_value
-                for detail_key, detail_value in value.items()
-                if isinstance(detail_value, int) and not isinstance(detail_value, bool)
-            }
-            if details:
-                normalized[str(key)] = details
-
-    required_keys = ("input_tokens", "output_tokens", "total_tokens")
-    if not all(isinstance(normalized.get(key), int) for key in required_keys):
-        return None
-    return normalized  # type: ignore[return-value]
-
-
-def _model_identity(request: ModelRequest, response: ModelResponse) -> dict[str, str]:
-    """依次从模型元数据、运行时上下文配置的 model spec、model_cache 和响应元数据解析模型身份信息。"""
-    model_metadata = getattr(request.model, "metadata", None) or {}
-    runtime_context = getattr(request.runtime, "context", None)
-    configured_spec = getattr(runtime_context, "model", None)
-    configured_spec = configured_spec.strip() if isinstance(configured_spec, str) else ""
-
-    identity: dict[str, str] = {}
-    for key, meta_key in (
-        ("provider_id", "yuxi_provider_id"),
-        ("provider_type", "yuxi_provider_type"),
-        ("configured_model_id", "yuxi_model_id"),
-        ("configured_model_spec", "yuxi_model_spec"),
-    ):
-        value = model_metadata.get(meta_key)
-        if isinstance(value, str) and value:
-            identity[key] = value
-
-    if not identity and configured_spec:
-        model_info = model_cache.get_model_info(configured_spec)
-        if model_info:
-            identity = {
-                "provider_id": model_info.provider_id,
-                "provider_type": model_info.provider_type,
-                "configured_model_id": model_info.model_id,
-                "configured_model_spec": model_info.spec,
-            }
-        else:
-            identity["configured_model_spec"] = configured_spec
-    elif configured_spec:
-        identity["configured_model_spec"] = configured_spec
-
-    message = _ai_message_from_response(response)
-    response_metadata = getattr(message, "response_metadata", None) if message else None
-    if isinstance(response_metadata, Mapping):
-        response_model_id = response_metadata.get("model_name") or response_metadata.get("model")
-        if isinstance(response_model_id, str) and response_model_id:
-            identity["response_model_id"] = response_model_id
-        if "provider_type" not in identity:
-            response_provider = response_metadata.get("model_provider")
-            if isinstance(response_provider, str) and response_provider:
-                identity["provider_type"] = response_provider
-
-    return identity
-
-
-def _usage_input_tokens(usage: Mapping[str, Any] | None) -> int:
-    """读取 usage 中的 input_tokens，缺失或非法时返回 0。"""
-    value = usage.get("input_tokens") if usage else None
-    return value if isinstance(value, int) and not isinstance(value, bool) else 0
-
-
-def _cache_read_tokens(usage: Mapping[str, Any] | None) -> int | None:
-    """按优先级从 input_token_details 中读取缓存命中 token 数，未观测到缓存字段时返回 None。"""
-    details = usage.get("input_token_details") if usage else None
-    if not isinstance(details, Mapping):
-        return None
-    for key in ("cache_read", "priority_cache_read", "flex_cache_read"):
-        if key not in details:
-            continue
-        value = details.get(key)
-        return value if isinstance(value, int) and not isinstance(value, bool) else None
     return None
 
 
@@ -388,174 +446,133 @@ def _add_call_to_aggregate(
     return result
 
 
-class TokenUsageMiddleware(AgentMiddleware[TokenUsageState]):
-    """Record approximate context token usage for the current model request."""
+def _model_context_window(model: Any) -> int | None:
+    """读取模型配置的上下文窗口大小，未配置或非法时返回 None。"""
+    profile = getattr(model, "profile", None)
+    if not isinstance(profile, Mapping):
+        return None
+    max_input_tokens = profile.get("max_input_tokens")
+    return max_input_tokens if isinstance(max_input_tokens, int) and max_input_tokens > 0 else None
 
-    state_schema = TokenUsageState
 
-    def __init__(self, token_counter=count_tokens_approximately) -> None:
-        super().__init__()
-        self.token_counter = token_counter
+def _summary_trigger_tokens(runtime_context: Any) -> int | None:
+    """读取运行时上下文的摘要触发阈值并转换为 token 数，未配置时返回 None。"""
+    threshold = _safe_int(getattr(runtime_context, "summary_threshold", None))
+    if threshold is None or threshold <= 0:
+        return None
+    return threshold * 1024
 
-    def _count_tokens(self, messages: Iterable[Any], *, tools: list[Any] | None = None) -> int:
-        message_list = list(messages)
-        if tools is not None:
-            return int(self.token_counter(message_list, tools=tools))
-        return int(self.token_counter(message_list))
 
-    def before_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
-        """在 Run 入口重置 Run 级用量，同时保留 v2 线程累计。"""
-        run_id = str(getattr(runtime.context, "run_id", None) or "")
-        previous = state.get("token_usage")
-        previous = previous if isinstance(previous, Mapping) else {}
-        same_run = previous.get("current_run_id") == run_id and isinstance(previous.get("run"), Mapping)
-        context_fields = {key: previous[key] for key in TOKEN_USAGE_CONTEXT_FIELDS if key in previous}
-        latest = previous.get("latest") if same_run else None
-        if isinstance(latest, Mapping):
-            latest_model = latest.get("model")
-            latest_bucket_key = latest.get("bucket_key")
-            latest_provider_id = latest_model.get("provider_id") if isinstance(latest_model, Mapping) else None
-            if latest_provider_id in TOKEN_USAGE_PROVIDER_BLACKLIST or (
-                isinstance(latest_bucket_key, str)
-                and latest_bucket_key.split(":", 1)[0] in TOKEN_USAGE_PROVIDER_BLACKLIST
-            ):
-                latest = None
-        return {
-            "token_usage": {
-                **context_fields,
-                "current_run_id": run_id,
-                "latest": latest,
-                "run": _without_blacklisted_providers(previous.get("run")) if same_run else _empty_aggregate(),
-                "thread": _without_blacklisted_providers(previous.get("thread")),
+def _is_summary_message(message: AnyMessage) -> bool:
+    """判断消息是否为摘要中间件产生的摘要消息。"""
+    return getattr(message, "additional_kwargs", {}).get("lc_source") == "summarization"
+
+
+def _is_tool_message(message: AnyMessage) -> bool:
+    """判断消息是否为工具消息。"""
+    return getattr(message, "type", None) == "tool" or getattr(message, "role", None) == "tool"
+
+
+def _ai_message_from_response(response: ModelResponse) -> AIMessage | None:
+    """从模型响应结果中取最后一条 AIMessage。"""
+    for message in reversed(response.result):
+        if isinstance(message, AIMessage):
+            return message
+    return None
+
+
+def _model_usage_from_response(response: ModelResponse) -> dict[str, Any] | None:
+    """提取响应中 AIMessage 携带的原始 usage_metadata。"""
+    message = _ai_message_from_response(response)
+    usage = getattr(message, "usage_metadata", None) if message else None
+    return dict(usage) if isinstance(usage, Mapping) else None
+
+
+def _usage_for_accumulation(usage: Mapping[str, Any] | None) -> UsageMetadata | None:
+    """保留可累计的数值 token 字段，忽略 Provider 的非数值扩展元数据。"""
+    if not usage:
+        return None
+
+    normalized: dict[str, Any] = {}
+    for key, value in usage.items():
+        if isinstance(value, int) and not isinstance(value, bool):
+            normalized[str(key)] = value
+            continue
+        if isinstance(value, Mapping):
+            details = {
+                str(detail_key): detail_value
+                for detail_key, detail_value in value.items()
+                if isinstance(detail_value, int) and not isinstance(detail_value, bool)
             }
-        }
+            if details:
+                normalized[str(key)] = details
 
-    async def abefore_agent(self, state: TokenUsageState, runtime: Any) -> dict[str, Any] | None:
-        """异步入口复用同步 Run 初始化逻辑。"""
-        return self.before_agent(state, runtime)
+    required_keys = ("input_tokens", "output_tokens", "total_tokens")
+    if not all(isinstance(normalized.get(key), int) for key in required_keys):
+        return None
+    return normalized  # type: ignore[return-value]
 
-    def _build_snapshot(self, request: ModelRequest, response: ModelResponse) -> TokenUsagePayload:
-        state_messages = list(request.state.get("messages") or [])
-        llm_messages = list(request.messages or [])
-        system_messages = [request.system_message] if request.system_message is not None else []
-        tools = list(request.tools or [])
-        response_messages = list(response.result or [])
 
-        state_tokens_before_call = self._count_tokens(state_messages)
-        next_state_messages = [*state_messages, *response_messages]
-        state_messages_tokens = self._count_tokens(next_state_messages)
-        llm_messages_tokens = self._count_tokens(llm_messages)
-        system_tokens = self._count_tokens(system_messages)
-        tools_tokens = self._count_tokens([], tools=tools) if tools else 0
-        llm_input_tokens = self._count_tokens([*system_messages, *llm_messages], tools=tools)
+def _usage_input_tokens(usage: Mapping[str, Any] | None) -> int:
+    """读取 usage 中的 input_tokens，缺失或非法时返回 0。"""
+    value = usage.get("input_tokens") if usage else None
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
-        context_window = _model_context_window(request.model)
-        context_usage_ratio = None
-        remaining_context_tokens = None
-        if context_window:
-            context_usage_ratio = min(1.0, round(llm_input_tokens / context_window, 4))
-            remaining_context_tokens = max(context_window - llm_input_tokens, 0)
 
-        summary_message = llm_messages[0] if llm_messages and _is_summary_message(llm_messages[0]) else None
-        llm_tool_messages = [message for message in llm_messages if _is_tool_message(message)]
-        llm_content_messages = [
-            message for message in llm_messages if not _is_tool_message(message) and not _is_summary_message(message)
-        ]
-        summary_trigger_tokens = _summary_trigger_tokens(getattr(request.runtime, "context", None))
-        previous_snapshot = request.state.get("token_usage")
-        previous_snapshot = previous_snapshot if isinstance(previous_snapshot, Mapping) else {}
-        model_usage = _model_usage_from_response(response)
-        identity = _model_identity(request, response)
-        runtime_context = getattr(request.runtime, "context", None)
-        run_id = str(getattr(runtime_context, "run_id", None) or "")
-        previous_run = previous_snapshot.get("run") if previous_snapshot.get("current_run_id") == run_id else None
-        measured_at = datetime.now(UTC).isoformat()
-        latest_usage = None
-        run_usage = _without_blacklisted_providers(
-            previous_run if isinstance(previous_run, Mapping) else _empty_aggregate()
-        )
-        thread_usage = _without_blacklisted_providers(previous_snapshot.get("thread"))
+def _cache_read_tokens(usage: Mapping[str, Any] | None) -> int | None:
+    """按优先级从 input_token_details 中读取缓存命中 token 数，未观测到缓存字段时返回 None。"""
+    details = usage.get("input_token_details") if usage else None
+    if not isinstance(details, Mapping):
+        return None
+    for key in ("cache_read", "priority_cache_read", "flex_cache_read"):
+        if key not in details:
+            continue
+        value = details.get(key)
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+    return None
 
-        if identity.get("provider_id") not in TOKEN_USAGE_PROVIDER_BLACKLIST:
-            bucket_key, identity_source = _bucket_key(identity, request.model)
-            run_usage = _add_call_to_aggregate(
-                run_usage,
-                bucket_key=bucket_key,
-                identity_source=identity_source,
-                identity=identity,
-                usage=model_usage,
-            )
-            thread_usage = _add_call_to_aggregate(
-                thread_usage,
-                bucket_key=bucket_key,
-                identity_source=identity_source,
-                identity=identity,
-                usage=model_usage,
-            )
-            cache_read_tokens = _cache_read_tokens(model_usage)
-            input_tokens = _usage_input_tokens(model_usage)
-            latest_usage = {
-                "bucket_key": bucket_key,
-                "model": identity,
-                "usage": model_usage or {},
-                "uncached_input_tokens": (
-                    max(input_tokens - cache_read_tokens, 0) if cache_read_tokens is not None else None
-                ),
-                "cache_hit_ratio": (_ratio(cache_read_tokens, input_tokens) if cache_read_tokens is not None else None),
-                "measured_at": measured_at,
+
+def _model_identity(request: ModelRequest, response: ModelResponse) -> dict[str, str]:
+    """依次从模型元数据、运行时上下文配置的 model spec、model_cache 和响应元数据解析模型身份信息。"""
+    model_metadata = getattr(request.model, "metadata", None) or {}
+    runtime_context = getattr(request.runtime, "context", None)
+    configured_spec = getattr(runtime_context, "model", None)
+    configured_spec = configured_spec.strip() if isinstance(configured_spec, str) else ""
+
+    identity: dict[str, str] = {}
+    for key, meta_key in (
+        ("provider_id", "yuxi_provider_id"),
+        ("provider_type", "yuxi_provider_type"),
+        ("configured_model_id", "yuxi_model_id"),
+        ("configured_model_spec", "yuxi_model_spec"),
+    ):
+        value = model_metadata.get(meta_key)
+        if isinstance(value, str) and value:
+            identity[key] = value
+
+    if not identity and configured_spec:
+        model_info = model_cache.get_model_info(configured_spec)
+        if model_info:
+            identity = {
+                "provider_id": model_info.provider_id,
+                "provider_type": model_info.provider_type,
+                "configured_model_id": model_info.model_id,
+                "configured_model_spec": model_info.spec,
             }
         else:
-            run_usage = _add_unavailable_call(run_usage)
-            thread_usage = _add_unavailable_call(thread_usage)
+            identity["configured_model_spec"] = configured_spec
+    elif configured_spec:
+        identity["configured_model_spec"] = configured_spec
 
-        return {
-            "state_message_count": len(next_state_messages),
-            "state_message_count_before_call": len(state_messages),
-            "state_messages_tokens": state_messages_tokens,
-            "state_messages_tokens_before_call": state_tokens_before_call,
-            "llm_message_count": len(llm_messages),
-            "llm_messages_tokens": llm_messages_tokens,
-            "llm_content_message_count": len(llm_content_messages),
-            "llm_content_message_tokens": self._count_tokens(llm_content_messages),
-            "llm_tool_message_count": len(llm_tool_messages),
-            "llm_tool_message_tokens": self._count_tokens(llm_tool_messages),
-            "llm_input_tokens": llm_input_tokens,
-            "system_tokens": system_tokens,
-            "tools_tokens": tools_tokens,
-            "tool_count": len(tools),
-            "context_window": context_window,
-            "context_usage_ratio": context_usage_ratio,
-            "remaining_context_tokens": remaining_context_tokens,
-            "summary_active": summary_message is not None,
-            "summary_message_tokens": self._count_tokens([summary_message]) if summary_message else 0,
-            "summary_trigger_tokens": summary_trigger_tokens,
-            "current_run_id": run_id,
-            "latest": latest_usage,
-            "run": run_usage,
-            "thread": thread_usage,
-            "counter": "langchain.count_tokens_approximately",
-            "estimate": True,
-            "measured_at": measured_at,
-        }
+    message = _ai_message_from_response(response)
+    response_metadata = getattr(message, "response_metadata", None) if message else None
+    if isinstance(response_metadata, Mapping):
+        response_model_id = response_metadata.get("model_name") or response_metadata.get("model")
+        if isinstance(response_model_id, str) and response_model_id:
+            identity["response_model_id"] = response_model_id
+        if "provider_type" not in identity:
+            response_provider = response_metadata.get("model_provider")
+            if isinstance(response_provider, str) and response_provider:
+                identity["provider_type"] = response_provider
 
-    def wrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], ModelResponse],
-    ) -> ExtendedModelResponse:
-        response = handler(request)
-        return ExtendedModelResponse(
-            model_response=response,
-            command=Command(update={"token_usage": self._build_snapshot(request, response)}),
-        )
-
-    async def awrap_model_call(
-        self,
-        request: ModelRequest,
-        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
-    ) -> ExtendedModelResponse:
-        response = await handler(request)
-        return ExtendedModelResponse(
-            model_response=response,
-            command=Command(update={"token_usage": self._build_snapshot(request, response)}),
-        )
+    return identity

--- a/backend/package/yuxi/agents/models.py
+++ b/backend/package/yuxi/agents/models.py
@@ -42,6 +42,17 @@ def load_chat_model(fully_specified_name: str | None, **kwargs) -> BaseChatModel
         extra_body.update(info.request_body_overrides)
         kwargs = {**kwargs, "extra_body": extra_body}
 
+    metadata = dict(kwargs.pop("metadata", {}) or {})
+    metadata.update(
+        {
+            "yuxi_provider_id": info.provider_id,
+            "yuxi_provider_type": info.provider_type,
+            "yuxi_model_id": info.model_id,
+            "yuxi_model_spec": info.spec,
+        }
+    )
+    kwargs["metadata"] = metadata
+
     logger.debug(f"Loading model {fully_specified_name} with provider_type={info.provider_type}")
 
     if info.provider_type == "anthropic":

--- a/backend/package/yuxi/repositories/agent_run_repository.py
+++ b/backend/package/yuxi/repositories/agent_run_repository.py
@@ -240,6 +240,7 @@ class AgentRunRepository:
         status: str,
         error_type: str | None = None,
         error_message: str | None = None,
+        token_usage: dict | None = None,
     ) -> tuple[AgentRun | None, bool]:
         run = await self._lock_run(run_id)
         if not run:
@@ -249,6 +250,7 @@ class AgentRunRepository:
         run.status = status
         run.error_type = error_type
         run.error_message = error_message
+        run.token_usage = token_usage or {}
         run.finished_at = utc_now_naive()
         run.updated_at = run.finished_at
         await self.db.flush()

--- a/backend/package/yuxi/services/agent_run_service.py
+++ b/backend/package/yuxi/services/agent_run_service.py
@@ -845,6 +845,7 @@ async def get_agent_run_result(*, run_id: str, current_uid: str, db: AsyncSessio
         "request_id": run.request_id,
         "final_message_id": output_message.id if output_message else None,
         "langfuse_trace_id": output_metadata.get("langfuse_trace_id"),
+        "token_usage": getattr(run, "token_usage", None) or {},
     }
     if run.error_type or run.error_message:
         payload["error"] = {"type": run.error_type, "message": run.error_message}

--- a/backend/package/yuxi/services/chat_service.py
+++ b/backend/package/yuxi/services/chat_service.py
@@ -1007,11 +1007,7 @@ async def stream_agent_chat(
                             request_id=meta.get("request_id"),
                         )
                         meta["time_cost"] = asyncio.get_event_loop().time() - start_time
-                        yield make_chunk(
-                            status="interrupted",
-                            message="检测到敏感内容，已中断输出",
-                            meta=meta,
-                        )
+                        yield make_chunk(status="interrupted", message="检测到敏感内容，已中断输出", meta=meta)
                         return
 
                 yield make_chunk(
@@ -1036,11 +1032,7 @@ async def stream_agent_chat(
                 request_id=meta.get("request_id"),
             )
             meta["time_cost"] = asyncio.get_event_loop().time() - start_time
-            yield make_chunk(
-                status="interrupted",
-                message="检测到敏感内容，已中断输出",
-                meta=meta,
-            )
+            yield make_chunk(status="interrupted", message="检测到敏感内容，已中断输出", meta=meta)
             return
 
         interrupted = False
@@ -1110,11 +1102,7 @@ async def stream_agent_chat(
         except Exception as exc:
             logger.error(f"Error during cleanup save: {exc}")
 
-        yield make_chunk(
-            status="interrupted",
-            message="对话已中断",
-            meta=meta,
-        )
+        yield make_chunk(status="interrupted", message="对话已中断", meta=meta)
 
     except Exception as e:
         logger.exception(f"Error streaming messages: {e}")
@@ -1137,12 +1125,7 @@ async def stream_agent_chat(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_chunk(
-            status="error",
-            error_type=error_type,
-            error_message=error_msg,
-            meta=meta,
-        )
+        yield make_chunk(status="error", error_type=error_type, error_message=error_msg, meta=meta)
     finally:
         flush_langfuse()
 
@@ -1337,11 +1320,7 @@ async def stream_agent_resume(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_resume_chunk(
-            status="interrupted",
-            message="对话恢复已中断",
-            meta=meta,
-        )
+        yield make_resume_chunk(status="interrupted", message="对话恢复已中断", meta=meta)
 
     except Exception as e:
         logger.exception(f"Error during resume: {e}")
@@ -1358,10 +1337,7 @@ async def stream_agent_resume(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_resume_chunk(
-            message=f"Error during resume: {e}",
-            status="error",
-        )
+        yield make_resume_chunk(message=f"Error during resume: {e}", status="error")
     finally:
         flush_langfuse()
 
@@ -1393,6 +1369,7 @@ async def get_agent_state_view(
     current_user: User,
     db,
     include_messages: bool = False,
+    include_relations: bool = True,
 ) -> dict:
     from fastapi import HTTPException
 
@@ -1440,30 +1417,31 @@ async def get_agent_state_view(
                 **_build_pending_interrupt_payload(interrupt_info, thread_id),
                 "run_id": latest_run.id,
             }
-        relation = await SubagentThreadRepository(db).get_by_child_conversation_for_user(
-            conversation.id,
-            str(current_uid),
-        )
-        if relation:
-            parent_conversation = await conv_repo.get_conversation_by_id(relation.parent_conversation_id)
-            if (
-                not parent_conversation
-                or parent_conversation.uid != str(current_uid)
-                or parent_conversation.status == "deleted"
-            ):
-                raise HTTPException(status_code=404, detail="父对话线程不存在")
-            response["parent_thread_id"] = parent_conversation.thread_id
-            response["subagent_thread"] = relation.to_dict()
-            latest_run = await run_repo.get_latest_subagent_run_by_thread_for_user(
-                thread_id,
+        if include_relations:
+            relation = await SubagentThreadRepository(db).get_by_child_conversation_for_user(
+                conversation.id,
                 str(current_uid),
             )
-            if latest_run:
-                try:
-                    response["subagent_run"] = serialize_subagent_run_state(latest_run)
-                except ValueError as exc:
-                    logger.error(f"子智能体运行记录格式异常: thread_id={thread_id}, run_id={latest_run.id}, {exc}")
-                    raise HTTPException(status_code=500, detail="子智能体运行记录格式异常") from exc
+            if relation:
+                parent_conversation = await conv_repo.get_conversation_by_id(relation.parent_conversation_id)
+                if (
+                    not parent_conversation
+                    or parent_conversation.uid != str(current_uid)
+                    or parent_conversation.status == "deleted"
+                ):
+                    raise HTTPException(status_code=404, detail="父对话线程不存在")
+                response["parent_thread_id"] = parent_conversation.thread_id
+                response["subagent_thread"] = relation.to_dict()
+                latest_run = await run_repo.get_latest_subagent_run_by_thread_for_user(
+                    thread_id,
+                    str(current_uid),
+                )
+                if latest_run:
+                    try:
+                        response["subagent_run"] = serialize_subagent_run_state(latest_run)
+                    except ValueError as exc:
+                        logger.error(f"子智能体运行记录格式异常: thread_id={thread_id}, run_id={latest_run.id}, {exc}")
+                        raise HTTPException(status_code=500, detail="子智能体运行记录格式异常") from exc
         if include_messages:
             response["messages"] = _serialize_state_messages(values)
         return response

--- a/backend/package/yuxi/services/chat_service.py
+++ b/backend/package/yuxi/services/chat_service.py
@@ -1007,7 +1007,11 @@ async def stream_agent_chat(
                             request_id=meta.get("request_id"),
                         )
                         meta["time_cost"] = asyncio.get_event_loop().time() - start_time
-                        yield make_chunk(status="interrupted", message="检测到敏感内容，已中断输出", meta=meta)
+                        yield make_chunk(
+                            status="interrupted",
+                            message="检测到敏感内容，已中断输出",
+                            meta=meta,
+                        )
                         return
 
                 yield make_chunk(
@@ -1032,7 +1036,11 @@ async def stream_agent_chat(
                 request_id=meta.get("request_id"),
             )
             meta["time_cost"] = asyncio.get_event_loop().time() - start_time
-            yield make_chunk(status="interrupted", message="检测到敏感内容，已中断输出", meta=meta)
+            yield make_chunk(
+                status="interrupted",
+                message="检测到敏感内容，已中断输出",
+                meta=meta,
+            )
             return
 
         interrupted = False
@@ -1102,7 +1110,11 @@ async def stream_agent_chat(
         except Exception as exc:
             logger.error(f"Error during cleanup save: {exc}")
 
-        yield make_chunk(status="interrupted", message="对话已中断", meta=meta)
+        yield make_chunk(
+            status="interrupted",
+            message="对话已中断",
+            meta=meta,
+        )
 
     except Exception as e:
         logger.exception(f"Error streaming messages: {e}")
@@ -1125,7 +1137,12 @@ async def stream_agent_chat(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_chunk(status="error", error_type=error_type, error_message=error_msg, meta=meta)
+        yield make_chunk(
+            status="error",
+            error_type=error_type,
+            error_message=error_msg,
+            meta=meta,
+        )
     finally:
         flush_langfuse()
 
@@ -1320,7 +1337,11 @@ async def stream_agent_resume(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_resume_chunk(status="interrupted", message="对话恢复已中断", meta=meta)
+        yield make_resume_chunk(
+            status="interrupted",
+            message="对话恢复已中断",
+            meta=meta,
+        )
 
     except Exception as e:
         logger.exception(f"Error during resume: {e}")
@@ -1337,7 +1358,10 @@ async def stream_agent_resume(
                 request_id=meta.get("request_id"),
             )
 
-        yield make_resume_chunk(message=f"Error during resume: {e}", status="error")
+        yield make_resume_chunk(
+            message=f"Error during resume: {e}",
+            status="error",
+        )
     finally:
         flush_langfuse()
 

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -19,7 +19,7 @@ from yuxi.services.agent_request_queue_service import (
     dispatch_next_request,
     recover_pending_dispatches,
 )
-from yuxi.services.chat_service import stream_agent_chat, stream_agent_resume
+from yuxi.services.chat_service import get_agent_state_view, stream_agent_chat, stream_agent_resume
 from yuxi.services.input_message_service import restore_chat_input_message
 from yuxi.services.run_queue_service import (
     append_run_stream_event,
@@ -156,7 +156,13 @@ async def mark_run_running(run_id: str):
         await repo.mark_running(run_id)
 
 
-async def mark_run_terminal(run_id: str, status: str, error_type: str | None = None, error_message: str | None = None):
+async def mark_run_terminal(
+    run_id: str,
+    status: str,
+    error_type: str | None = None,
+    error_message: str | None = None,
+    token_usage: dict | None = None,
+):
     async with pg_manager.get_async_session_context() as db:
         repo = AgentRunRepository(db)
         run, changed = await repo.set_terminal_status(
@@ -164,6 +170,7 @@ async def mark_run_terminal(run_id: str, status: str, error_type: str | None = N
             status=status,
             error_type=error_type,
             error_message=error_message,
+            token_usage=token_usage,
         )
         persisted_status = run.status if run else None
         delivery_status = RUN_STATUS_TO_DELIVERY_STATUS.get(persisted_status or "")
@@ -183,6 +190,27 @@ async def _load_user(uid: str):
 async def _is_cancel_requested(run_id: str) -> bool:
     run = await _get_run(run_id)
     return bool(run and run.status == "cancel_requested")
+
+
+async def _read_run_token_usage_from_state(*, run_id: str, thread_id: str, current_user) -> dict | None:
+    """从当前线程 state 读取属于指定 Run 的用量快照。"""
+    try:
+        async with pg_manager.get_async_session_context() as db:
+            view = await get_agent_state_view(
+                thread_id=thread_id,
+                current_user=current_user,
+                db=db,
+            )
+    except Exception:
+        logger.warning(f"Failed to read token usage from state for run {run_id}", exc_info=True)
+        return None
+
+    agent_state = view.get("agent_state") if isinstance(view, dict) else None
+    token_usage = agent_state.get("token_usage") if isinstance(agent_state, dict) else None
+    if not isinstance(token_usage, dict) or token_usage.get("current_run_id") != run_id:
+        return None
+    run_usage = token_usage.get("run")
+    return dict(run_usage) if isinstance(run_usage, dict) else None
 
 
 def _job_try(ctx) -> int:
@@ -272,14 +300,25 @@ async def _finish_run(
     *,
     thread_id: str | None,
     chunk: dict,
+    current_user,
     error_type: str | None = None,
     error_message: str | None = None,
 ) -> TerminalTransition:
+    token_usage = {}
+    if thread_id:
+        state_token_usage = await _read_run_token_usage_from_state(
+            run_id=run_id,
+            thread_id=thread_id,
+            current_user=current_user,
+        )
+        if state_token_usage is not None:
+            token_usage = state_token_usage
     transition = await mark_run_terminal(
         run_id,
         status,
         error_type=error_type,
         error_message=error_message,
+        token_usage=token_usage,
     )
     if transition.changed and transition.status:
         await _append_end_event(run_id, transition.status, thread_id=thread_id, payload={"chunk": chunk})
@@ -426,7 +465,6 @@ async def process_agent_run(ctx, run_id: str):
     )
     terminal_set = False
     pending_interrupt: tuple[dict, str | None] | None = None
-
     try:
         async with pg_manager.get_async_session_context() as db:
             if run_type == "resume":
@@ -481,6 +519,7 @@ async def process_agent_run(ctx, run_id: str):
                             "completed",
                             thread_id=thread_id,
                             chunk=chunk,
+                            current_user=user,
                         )
                         terminal_set = transition.status is not None
                     elif status == "error":
@@ -491,6 +530,7 @@ async def process_agent_run(ctx, run_id: str):
                             chunk=chunk,
                             error_type=chunk.get("error_type") or "stream_error",
                             error_message=chunk.get("error_message") or chunk.get("message"),
+                            current_user=user,
                         )
                         terminal_set = transition.status is not None
                     elif status == "interrupted":
@@ -502,6 +542,7 @@ async def process_agent_run(ctx, run_id: str):
                             chunk=chunk,
                             error_type=status_value,
                             error_message=chunk.get("message"),
+                            current_user=user,
                         )
                         terminal_set = transition.status is not None
 
@@ -530,6 +571,7 @@ async def process_agent_run(ctx, run_id: str):
                     if interrupt_status == "human_approval_required"
                     else first_question or "需要用户回答问题"
                 ),
+                current_user=user,
             )
             terminal_set = transition.status is not None
 
@@ -542,16 +584,23 @@ async def process_agent_run(ctx, run_id: str):
                 "completed",
                 thread_id=thread_id,
                 chunk=finished_chunk,
+                current_user=user,
             )
 
     except asyncio.CancelledError:
         await writer.flush()
         cancel_chunk = {"status": "interrupted", "message": "对话已取消", "request_id": request_id}
+        state_token_usage = await _read_run_token_usage_from_state(
+            run_id=run_id,
+            thread_id=thread_id,
+            current_user=user,
+        )
         transition = await mark_run_terminal(
             run_id,
             "cancelled",
             error_type="cancelled",
             error_message="对话已取消",
+            token_usage=state_token_usage or {},
         )
         if transition.changed:
             await append_run_event(
@@ -591,6 +640,7 @@ async def process_agent_run(ctx, run_id: str):
                     chunk=retryable_error_chunk,
                     error_type="retryable_worker_error",
                     error_message=str(e),
+                    current_user=user,
                 )
                 logger.error(f"Run failed after retries exhausted {run_id}: {e}")
                 return
@@ -620,6 +670,7 @@ async def process_agent_run(ctx, run_id: str):
             chunk=error_chunk,
             error_type="worker_error",
             error_message=str(e),
+            current_user=user,
         )
         return
     finally:

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -200,6 +200,7 @@ async def _read_run_token_usage_from_state(*, run_id: str, thread_id: str, curre
                 thread_id=thread_id,
                 current_user=current_user,
                 db=db,
+                include_relations=False,
             )
     except Exception:
         logger.warning(f"Failed to read token usage from state for run {run_id}", exc_info=True)

--- a/backend/package/yuxi/services/run_worker.py
+++ b/backend/package/yuxi/services/run_worker.py
@@ -304,7 +304,7 @@ async def _finish_run(
     error_type: str | None = None,
     error_message: str | None = None,
 ) -> TerminalTransition:
-    token_usage = {}
+    token_usage = {"available": False}
     if thread_id:
         state_token_usage = await _read_run_token_usage_from_state(
             run_id=run_id,
@@ -600,7 +600,7 @@ async def process_agent_run(ctx, run_id: str):
             "cancelled",
             error_type="cancelled",
             error_message="对话已取消",
-            token_usage=state_token_usage or {},
+            token_usage=state_token_usage or {"available": False},
         )
         if transition.changed:
             await append_run_event(

--- a/backend/package/yuxi/storage/postgres/manager.py
+++ b/backend/package/yuxi/storage/postgres/manager.py
@@ -656,6 +656,10 @@ class PostgresManager(metaclass=SingletonMeta):
                 "origin_metadata JSONB NOT NULL DEFAULT '{}'::jsonb"
             ),
             (
+                "ALTER TABLE IF EXISTS agent_runs ADD COLUMN IF NOT EXISTS "
+                "token_usage JSONB NOT NULL DEFAULT '{}'::jsonb"
+            ),
+            (
                 "ALTER TABLE IF EXISTS agent_run_requests ADD COLUMN IF NOT EXISTS "
                 "channel VARCHAR(32) NOT NULL DEFAULT 'web'"
             ),

--- a/backend/package/yuxi/storage/postgres/models_business.py
+++ b/backend/package/yuxi/storage/postgres/models_business.py
@@ -870,6 +870,7 @@ class AgentRun(Base):
     output_message_id = Column(Integer, nullable=True, comment="Output message ID")
     last_event_id = Column(String(64), nullable=True, comment="Last Redis stream event ID")
     input_payload = Column(JSON, nullable=False, default=dict, comment="Original input payload")
+    token_usage = Column(JSON_VALUE, nullable=False, default=dict, comment="Run token usage grouped by model")
     error_type = Column(String(64), nullable=True, comment="Error type")
     error_message = Column(Text, nullable=True, comment="Error message")
     started_at = Column(DateTime, nullable=True, comment="Start time")
@@ -897,6 +898,7 @@ class AgentRun(Base):
             "output_message_id": self.output_message_id,
             "last_event_id": self.last_event_id,
             "input_payload": self.input_payload or {},
+            "token_usage": self.token_usage or {},
             "error_type": self.error_type,
             "error_message": self.error_message,
             "started_at": format_utc_datetime(self.started_at),

--- a/backend/server/routers/agent_invocation_call_router.py
+++ b/backend/server/routers/agent_invocation_call_router.py
@@ -229,7 +229,7 @@ def _build_agent_call_response(result: dict[str, Any]) -> dict[str, Any]:
                 "finish_reason": _finish_reason(status),
             }
         ],
-        "usage": _normalize_usage(token_total or result.get("usage")),
+        "usage": _normalize_usage(token_total),
     }
     if result.get("error"):
         payload["error"] = result["error"]

--- a/backend/server/routers/agent_invocation_call_router.py
+++ b/backend/server/routers/agent_invocation_call_router.py
@@ -213,9 +213,7 @@ def _build_agent_call_response(result: dict[str, Any]) -> dict[str, Any]:
     output = result.get("output") if isinstance(result.get("output"), str) else ""
     token_usage = result.get("token_usage")
     token_total = (
-        token_usage.get("total")
-        if isinstance(token_usage, dict) and token_usage.get("available") is not False
-        else None
+        token_usage.get("total") if isinstance(token_usage, dict) and token_usage.get("complete") is True else None
     )
     payload: dict[str, Any] = {
         "run_id": result.get("agent_run_id") or result.get("run_id"),

--- a/backend/server/routers/agent_invocation_call_router.py
+++ b/backend/server/routers/agent_invocation_call_router.py
@@ -211,6 +211,8 @@ def _build_agent_call_response(result: dict[str, Any]) -> dict[str, Any]:
     raw_status = str(result.get("status") or "unknown")
     status = "pending" if raw_status == "dispatched" else raw_status
     output = result.get("output") if isinstance(result.get("output"), str) else ""
+    token_usage = result.get("token_usage")
+    token_total = token_usage.get("total") if isinstance(token_usage, dict) else None
     payload: dict[str, Any] = {
         "run_id": result.get("agent_run_id") or result.get("run_id"),
         "agent_slug": result.get("agent_slug"),
@@ -225,7 +227,7 @@ def _build_agent_call_response(result: dict[str, Any]) -> dict[str, Any]:
                 "finish_reason": _finish_reason(status),
             }
         ],
-        "usage": _normalize_usage(result.get("usage")),
+        "usage": _normalize_usage(token_total or result.get("usage")),
     }
     if result.get("error"):
         payload["error"] = result["error"]

--- a/backend/server/routers/agent_invocation_call_router.py
+++ b/backend/server/routers/agent_invocation_call_router.py
@@ -193,10 +193,10 @@ def _extract_input_message(messages: list[dict[str, Any]]) -> AgentRunInputMessa
     raise HTTPException(status_code=422, detail="messages 必须包含 user 消息")
 
 
-def _normalize_usage(usage: object) -> dict[str, int]:
+def _normalize_usage(usage: object) -> dict[str, int] | None:
     """把不同来源的 usage 字段归一为 OpenAI-compatible 计数字段。"""
     if not isinstance(usage, dict):
-        return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        return None
     prompt = usage.get("prompt_tokens", usage.get("input_tokens", 0))
     completion = usage.get("completion_tokens", usage.get("output_tokens", 0))
     total = usage.get("total_tokens")
@@ -212,7 +212,11 @@ def _build_agent_call_response(result: dict[str, Any]) -> dict[str, Any]:
     status = "pending" if raw_status == "dispatched" else raw_status
     output = result.get("output") if isinstance(result.get("output"), str) else ""
     token_usage = result.get("token_usage")
-    token_total = token_usage.get("total") if isinstance(token_usage, dict) else None
+    token_total = (
+        token_usage.get("total")
+        if isinstance(token_usage, dict) and token_usage.get("available") is not False
+        else None
+    )
     payload: dict[str, Any] = {
         "run_id": result.get("agent_run_id") or result.get("run_id"),
         "agent_slug": result.get("agent_slug"),

--- a/backend/test/unit/middlewares/test_token_usage_middleware.py
+++ b/backend/test/unit/middlewares/test_token_usage_middleware.py
@@ -9,90 +9,310 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from yuxi.agents.middlewares.token_usage import TokenUsageMiddleware
 
 
-@pytest.mark.asyncio
-async def test_token_usage_middleware_records_request_and_state_tokens() -> None:
-    middleware = TokenUsageMiddleware()
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "search_docs",
-            "description": "Search project documents.",
-            "parameters": {
-                "type": "object",
-                "properties": {"query": {"type": "string"}},
-                "required": ["query"],
+def _request(*, run_id: str, model_spec: str, state: dict | None = None, model_name: str = "model-a"):
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            profile={"max_input_tokens": 2000},
+            metadata={
+                "yuxi_provider_id": model_spec.split(":", 1)[0],
+                "yuxi_provider_type": "openai",
+                "yuxi_model_id": model_name,
+                "yuxi_model_spec": model_spec,
             },
-        },
-    }
-    request = SimpleNamespace(
-        model=SimpleNamespace(profile={"max_input_tokens": 2000}),
-        state={"messages": [HumanMessage(content="old message")]},
+        ),
+        state=state or {"messages": [HumanMessage(content="old message")]},
         messages=[
             HumanMessage(content="current message"),
             ToolMessage(content="tool result", tool_call_id="call_1"),
         ],
         system_message=SystemMessage(content="system prompt"),
-        tools=[tool_schema],
-        runtime=SimpleNamespace(context=SimpleNamespace(summary_threshold=2)),
+        tools=[],
+        runtime=SimpleNamespace(context=SimpleNamespace(summary_threshold=2, model=model_spec, run_id=run_id)),
     )
 
+
+def _response(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read: int | None,
+    response_model: str,
+    cache_read_key: str = "cache_read",
+):
+    input_details = {} if cache_read is None else {cache_read_key: cache_read}
+    return ModelResponse(
+        result=[
+            AIMessage(
+                content="answer",
+                usage_metadata={
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                    "input_token_details": input_details,
+                    "output_token_details": {"reasoning": 3},
+                    "provider_label": "priority",
+                },
+                response_metadata={"model_name": response_model, "model_provider": "openai"},
+            )
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_records_context_and_run_usage() -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="provider-a:model-a")
+
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
     async def handler(_request):
-        return ModelResponse(
-            result=[
-                AIMessage(
-                    content="answer",
-                    usage_metadata={"input_tokens": 12, "output_tokens": 5, "total_tokens": 17},
-                )
-            ]
-        )
+        return _response(input_tokens=12, output_tokens=5, cache_read=8, response_model="model-a-2026")
 
     result = await middleware.awrap_model_call(request, handler)
 
     assert isinstance(result, ExtendedModelResponse)
     token_usage = result.command.update["token_usage"]
-    assert token_usage["state_message_count"] == 2
-    assert token_usage["state_message_count_before_call"] == 1
-    assert token_usage["llm_message_count"] == 2
-    assert token_usage["llm_content_message_count"] == 1
-    assert token_usage["llm_content_message_tokens"] > 0
-    assert token_usage["llm_tool_message_count"] == 1
-    assert token_usage["llm_tool_message_tokens"] > 0
-    assert token_usage["state_messages_tokens"] >= token_usage["state_messages_tokens_before_call"]
     assert token_usage["llm_input_tokens"] >= token_usage["llm_messages_tokens"]
-    assert token_usage["system_tokens"] > 0
-    assert token_usage["tools_tokens"] > 0
-    assert token_usage["tool_count"] == 1
     assert token_usage["context_window"] == 2000
-    assert token_usage["remaining_context_tokens"] == 2000 - token_usage["llm_input_tokens"]
-    assert token_usage["summary_trigger_tokens"] == 2048
-    assert "summary_keep_tokens" not in token_usage
-    assert token_usage["model_usage"] == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
-    assert token_usage["estimate"] is True
+    assert token_usage["current_run_id"] == "run-1"
+    assert token_usage["latest"]["bucket_key"] == "provider-a:model-a"
+    assert token_usage["latest"]["usage"]["provider_label"] == "priority"
+
+    bucket = token_usage["run"]["models"]["provider-a:model-a"]
+    assert bucket["model"]["response_model_ids"] == ["model-a-2026"]
+    assert bucket["usage"] == {
+        "input_tokens": 12,
+        "output_tokens": 5,
+        "total_tokens": 17,
+        "input_token_details": {"cache_read": 8},
+        "output_token_details": {"reasoning": 3},
+    }
+    assert bucket["cache_hit_ratio"] == 0.6667
+    assert token_usage["run"]["total"] == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
+    assert token_usage["thread"] == token_usage["run"]
 
 
 @pytest.mark.asyncio
-async def test_token_usage_middleware_detects_effective_summary_message() -> None:
+async def test_token_usage_middleware_groups_multiple_models_within_one_run() -> None:
     middleware = TokenUsageMiddleware()
-    summary_message = HumanMessage(
-        content="conversation summary",
-        additional_kwargs={"lc_source": "summarization"},
-    )
-    request = SimpleNamespace(
-        model=SimpleNamespace(profile={}),
-        state={"messages": [HumanMessage(content="raw history")]},
-        messages=[summary_message, HumanMessage(content="recent user turn")],
-        system_message=None,
-        tools=[],
-        runtime=SimpleNamespace(context=SimpleNamespace(summary_threshold=100)),
+    request_a = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(request_a.state, request_a.runtime)
+    request_a.state["token_usage"] = initialized["token_usage"]
+
+    async def handler_a(_request):
+        return _response(input_tokens=100, output_tokens=20, cache_read=60, response_model="model-a-v1")
+
+    first = await middleware.awrap_model_call(request_a, handler_a)
+    request_b = _request(
+        run_id="run-1",
+        model_spec="provider-b:model-b",
+        model_name="model-b",
+        state={"messages": [], "token_usage": first.command.update["token_usage"]},
     )
 
+    async def handler_b(_request):
+        return _response(input_tokens=50, output_tokens=10, cache_read=None, response_model="model-b-v2")
+
+    second = await middleware.awrap_model_call(request_b, handler_b)
+    token_usage = second.command.update["token_usage"]
+
+    assert set(token_usage["run"]["models"]) == {"provider-a:model-a", "provider-b:model-b"}
+    assert token_usage["run"]["model_call_count"] == 2
+    assert token_usage["run"]["total"] == {"input_tokens": 150, "output_tokens": 30, "total_tokens": 180}
+    bucket_b = token_usage["run"]["models"]["provider-b:model-b"]
+    assert bucket_b["cache_observed_call_count"] == 0
+    assert bucket_b["cache_hit_ratio"] is None
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_resets_run_and_keeps_v2_thread_usage() -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
+    async def first_handler(_request):
+        return _response(input_tokens=100, output_tokens=20, cache_read=60, response_model="model-a")
+
+    first = await middleware.awrap_model_call(request, first_handler)
+    next_runtime = SimpleNamespace(context=SimpleNamespace(run_id="run-2"))
+    next_state = {"messages": [], "token_usage": first.command.update["token_usage"]}
+    reset = middleware.before_agent(next_state, next_runtime)["token_usage"]
+
+    assert reset["current_run_id"] == "run-2"
+    assert reset["latest"] is None
+    assert reset["run"]["models"] == {}
+    assert reset["thread"]["total"] == {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120}
+
+    next_request = _request(
+        run_id="run-2",
+        model_spec="provider-a:model-a",
+        state={"messages": [], "token_usage": reset},
+    )
+
+    async def second_handler(_request):
+        return _response(input_tokens=50, output_tokens=10, cache_read=20, response_model="model-a")
+
+    second = await middleware.awrap_model_call(next_request, second_handler)
+    second_usage = second.command.update["token_usage"]
+
+    assert second_usage["run"]["total"] == {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60}
+    assert second_usage["thread"]["total"] == {"input_tokens": 150, "output_tokens": 30, "total_tokens": 180}
+    thread_bucket = second_usage["thread"]["models"]["provider-a:model-a"]
+    assert thread_bucket["cache_read_input_tokens"] == 80
+    assert thread_bucket["cache_observed_input_tokens"] == 150
+
+
+def test_token_usage_middleware_removes_blacklisted_buckets_from_existing_v2_thread() -> None:
+    middleware = TokenUsageMiddleware()
+    state = {
+        "messages": [],
+        "token_usage": {
+            "current_run_id": "run-1",
+            "run": {"schema_version": 2, "models": {}, "total": {}},
+            "thread": {
+                "schema_version": 2,
+                "model_call_count": 2,
+                "usage_reported_call_count": 2,
+                "models": {
+                    "siliconflow-cn:model-a": {
+                        "model": {"provider_id": "siliconflow-cn"},
+                        "usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+                        "model_call_count": 1,
+                        "usage_reported_call_count": 1,
+                    },
+                    "provider-b:model-b": {
+                        "model": {"provider_id": "provider-b"},
+                        "usage": {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60},
+                        "model_call_count": 1,
+                        "usage_reported_call_count": 1,
+                    },
+                },
+                "total": {"input_tokens": 150, "output_tokens": 30, "total_tokens": 180},
+            },
+        },
+    }
+    runtime = SimpleNamespace(context=SimpleNamespace(run_id="run-2"))
+
+    reset = middleware.before_agent(state, runtime)["token_usage"]
+
+    assert set(reset["thread"]["models"]) == {"provider-b:model-b"}
+    assert reset["thread"]["total"] == {"input_tokens": 50, "output_tokens": 10, "total_tokens": 60}
+
+
+def test_token_usage_middleware_removes_blacklisted_buckets_when_resuming_same_run() -> None:
+    middleware = TokenUsageMiddleware()
+    blacklisted_bucket = {
+        "model": {"provider_id": "siliconflow"},
+        "usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+        "model_call_count": 1,
+        "usage_reported_call_count": 1,
+    }
+    state = {
+        "messages": [],
+        "token_usage": {
+            "current_run_id": "run-1",
+            "latest": {"bucket_key": "siliconflow:model-a"},
+            "run": {
+                "schema_version": 2,
+                "models": {"siliconflow:model-a": blacklisted_bucket},
+                "total": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+            },
+            "thread": {
+                "schema_version": 2,
+                "models": {"siliconflow:model-a": blacklisted_bucket},
+                "total": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+            },
+        },
+    }
+    runtime = SimpleNamespace(context=SimpleNamespace(run_id="run-1"))
+
+    resumed = middleware.before_agent(state, runtime)["token_usage"]
+
+    assert resumed["current_run_id"] == "run-1"
+    assert resumed["latest"] is None
+    assert resumed["run"]["models"] == {}
+    assert resumed["thread"]["models"] == {}
+
+
+def test_token_usage_middleware_discards_unattributed_v1_thread_totals() -> None:
+    middleware = TokenUsageMiddleware()
+    state = {
+        "messages": [],
+        "token_usage": {
+            "cumulative_model_usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+            "model": {"configured_model_spec": "provider-a:model-a"},
+        },
+    }
+    runtime = SimpleNamespace(context=SimpleNamespace(run_id="run-2"))
+
+    reset = middleware.before_agent(state, runtime)["token_usage"]
+
+    assert reset["thread"]["models"] == {}
+    assert reset["thread"]["total"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert "cumulative_model_usage" not in reset
+    assert "model" not in reset
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_distinguishes_reported_zero_cache_from_unknown() -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
     async def handler(_request):
-        return ModelResponse(result=[AIMessage(content="answer")])
+        return _response(input_tokens=0, output_tokens=1, cache_read=0, response_model="model-a")
+
+    result = await middleware.awrap_model_call(request, handler)
+    bucket = result.command.update["token_usage"]["run"]["models"]["provider-a:model-a"]
+
+    assert bucket["cache_observed_call_count"] == 1
+    assert bucket["cache_read_input_tokens"] == 0
+    assert bucket["cache_hit_ratio"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cache_read_key", ["priority_cache_read", "flex_cache_read"])
+async def test_token_usage_middleware_records_service_tier_cache_usage(cache_read_key: str) -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
+    async def handler(_request):
+        return _response(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read=40,
+            response_model="model-a",
+            cache_read_key=cache_read_key,
+        )
+
+    result = await middleware.awrap_model_call(request, handler)
+    bucket = result.command.update["token_usage"]["run"]["models"]["provider-a:model-a"]
+
+    assert bucket["cache_observed_call_count"] == 1
+    assert bucket["cache_read_input_tokens"] == 40
+    assert bucket["cache_hit_ratio"] == 0.4
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_skips_blacklisted_siliconflow_usage() -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="siliconflow-cn:model-a")
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
+    async def handler(_request):
+        return _response(input_tokens=100, output_tokens=20, cache_read=50, response_model="model-a")
 
     result = await middleware.awrap_model_call(request, handler)
     token_usage = result.command.update["token_usage"]
 
-    assert token_usage["summary_active"] is True
-    assert token_usage["summary_message_tokens"] > 0
-    assert token_usage["context_window"] is None
-    assert token_usage["context_usage_ratio"] is None
+    assert token_usage["llm_input_tokens"] > 0
+    assert token_usage["latest"] is None
+    assert token_usage["run"]["models"] == {}
+    assert token_usage["run"]["total"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert token_usage["thread"]["models"] == {}

--- a/backend/test/unit/middlewares/test_token_usage_middleware.py
+++ b/backend/test/unit/middlewares/test_token_usage_middleware.py
@@ -58,6 +58,17 @@ def _response(
     )
 
 
+def _response_without_usage(*, response_model: str):
+    return ModelResponse(
+        result=[
+            AIMessage(
+                content="answer",
+                response_metadata={"model_name": response_model, "model_provider": "openai"},
+            )
+        ]
+    )
+
+
 @pytest.mark.asyncio
 async def test_token_usage_middleware_records_context_and_run_usage() -> None:
     middleware = TokenUsageMiddleware()
@@ -89,6 +100,7 @@ async def test_token_usage_middleware_records_context_and_run_usage() -> None:
         "output_token_details": {"reasoning": 3},
     }
     assert bucket["cache_hit_ratio"] == 0.6667
+    assert token_usage["run"]["complete"] is True
     assert token_usage["run"]["total"] == {"input_tokens": 12, "output_tokens": 5, "total_tokens": 17}
     assert token_usage["thread"] == token_usage["run"]
 
@@ -123,6 +135,54 @@ async def test_token_usage_middleware_groups_multiple_models_within_one_run() ->
     bucket_b = token_usage["run"]["models"]["provider-b:model-b"]
     assert bucket_b["cache_observed_call_count"] == 0
     assert bucket_b["cache_hit_ratio"] is None
+    assert token_usage["run"]["complete"] is True
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_marks_missing_usage_incomplete() -> None:
+    middleware = TokenUsageMiddleware()
+    request = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(request.state, request.runtime)
+    request.state["token_usage"] = initialized["token_usage"]
+
+    async def handler(_request):
+        return _response_without_usage(response_model="model-a")
+
+    result = await middleware.awrap_model_call(request, handler)
+    aggregate = result.command.update["token_usage"]["run"]
+
+    assert aggregate["model_call_count"] == 1
+    assert aggregate["usage_reported_call_count"] == 0
+    assert aggregate["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_token_usage_middleware_marks_partial_usage_incomplete() -> None:
+    middleware = TokenUsageMiddleware()
+    first_request = _request(run_id="run-1", model_spec="provider-a:model-a")
+    initialized = middleware.before_agent(first_request.state, first_request.runtime)
+    first_request.state["token_usage"] = initialized["token_usage"]
+
+    async def first_handler(_request):
+        return _response(input_tokens=10, output_tokens=2, cache_read=None, response_model="model-a")
+
+    first = await middleware.awrap_model_call(first_request, first_handler)
+    second_request = _request(
+        run_id="run-1",
+        model_spec="provider-a:model-a",
+        state={"messages": [], "token_usage": first.command.update["token_usage"]},
+    )
+
+    async def second_handler(_request):
+        return _response_without_usage(response_model="model-a")
+
+    second = await middleware.awrap_model_call(second_request, second_handler)
+    aggregate = second.command.update["token_usage"]["run"]
+
+    assert aggregate["model_call_count"] == 2
+    assert aggregate["usage_reported_call_count"] == 1
+    assert aggregate["total"] == {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12}
+    assert aggregate["complete"] is False
 
 
 @pytest.mark.asyncio
@@ -314,5 +374,8 @@ async def test_token_usage_middleware_skips_blacklisted_siliconflow_usage() -> N
     assert token_usage["llm_input_tokens"] > 0
     assert token_usage["latest"] is None
     assert token_usage["run"]["models"] == {}
+    assert token_usage["run"]["model_call_count"] == 1
+    assert token_usage["run"]["usage_unavailable_call_count"] == 1
+    assert token_usage["run"]["complete"] is False
     assert token_usage["run"]["total"] == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
     assert token_usage["thread"]["models"] == {}

--- a/backend/test/unit/repositories/test_agent_run_repository.py
+++ b/backend/test/unit/repositories/test_agent_run_repository.py
@@ -109,3 +109,36 @@ async def test_create_run_persists_origin_snapshot(session):
     assert run.channel == "api"
     assert run.external_id == "external-1"
     assert run.origin_metadata == {"agent_invocation_meta": {"trace_id": "trace-1"}}
+
+
+async def test_set_terminal_status_persists_token_usage_only_for_winner(session):
+    repo = AgentRunRepository(session)
+    run = await repo.create_run(
+        run_id="usage-run",
+        conversation_thread_id="thread-1",
+        agent_slug="main",
+        uid="user-1",
+        request_id="usage-request",
+        input_payload={},
+    )
+    usage = {
+        "schema_version": 2,
+        "models": {"provider:model": {}},
+        "total": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+    }
+
+    persisted, changed = await repo.set_terminal_status(
+        run.id,
+        status="completed",
+        token_usage=usage,
+    )
+    loser, loser_changed = await repo.set_terminal_status(
+        run.id,
+        status="failed",
+        token_usage={"total": {"input_tokens": 999}},
+    )
+
+    assert changed is True
+    assert persisted.token_usage == usage
+    assert loser_changed is False
+    assert loser.token_usage == usage

--- a/backend/test/unit/services/test_agent_invocation_router_adapters.py
+++ b/backend/test/unit/services/test_agent_invocation_router_adapters.py
@@ -74,6 +74,7 @@ async def test_agent_call_adapter_waits_and_wraps_result(monkeypatch: pytest.Mon
             "request_id": "req-1",
             "token_usage": {
                 "schema_version": 2,
+                "complete": True,
                 "models": {"provider:model": {}},
                 "total": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
             },
@@ -103,6 +104,23 @@ def test_agent_call_response_keeps_unavailable_usage_distinct_from_zero():
             "status": "completed",
             "agent_run_id": "run-1",
             "token_usage": {"available": False},
+        }
+    )
+
+    assert result["usage"] is None
+
+
+def test_agent_call_response_rejects_partial_usage():
+    result = call_router._build_agent_call_response(
+        {
+            "status": "completed",
+            "agent_run_id": "run-1",
+            "token_usage": {
+                "complete": False,
+                "model_call_count": 2,
+                "usage_reported_call_count": 1,
+                "total": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+            },
         }
     )
 

--- a/backend/test/unit/services/test_agent_invocation_router_adapters.py
+++ b/backend/test/unit/services/test_agent_invocation_router_adapters.py
@@ -72,7 +72,11 @@ async def test_agent_call_adapter_waits_and_wraps_result(monkeypatch: pytest.Mon
             "thread_id": "thread-1",
             "agent_run_id": run_id,
             "request_id": "req-1",
-            "usage": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+            "token_usage": {
+                "schema_version": 2,
+                "models": {"provider:model": {}},
+                "total": {"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+            },
         }
 
     monkeypatch.setattr(call_router, "submit_run_command", fake_submit_run_command)

--- a/backend/test/unit/services/test_agent_invocation_router_adapters.py
+++ b/backend/test/unit/services/test_agent_invocation_router_adapters.py
@@ -97,6 +97,18 @@ async def test_agent_call_adapter_waits_and_wraps_result(monkeypatch: pytest.Mon
     assert calls["await"] == ("run-1", "user-1")
 
 
+def test_agent_call_response_keeps_unavailable_usage_distinct_from_zero():
+    result = call_router._build_agent_call_response(
+        {
+            "status": "completed",
+            "agent_run_id": "run-1",
+            "token_usage": {"available": False},
+        }
+    )
+
+    assert result["usage"] is None
+
+
 @pytest.mark.asyncio
 async def test_agent_call_adapter_rejects_invalid_sync_policy():
     with pytest.raises(HTTPException) as exc:

--- a/backend/test/unit/services/test_model_selectors.py
+++ b/backend/test/unit/services/test_model_selectors.py
@@ -184,6 +184,10 @@ def test_load_chat_model_uses_toolcall_chunk_fix_for_openai_compatible(monkeypat
     # 不再按 provider 禁用流式，改用归一化子类规避 v3 流式累积丢 tool_call 字段的缺陷
     assert isinstance(model, _ToolCallChunkFixChatOpenAI)
     assert model.disable_streaming is False
+    assert model.metadata["yuxi_provider_id"] == "siliconflow-cn"
+    assert model.metadata["yuxi_provider_type"] == "openai"
+    assert model.metadata["yuxi_model_id"] == "deepseek-ai/DeepSeek-V4-Flash"
+    assert model.metadata["yuxi_model_spec"] == "siliconflow-cn:deepseek-ai/DeepSeek-V4-Flash"
 
 
 def test_load_chat_model_keeps_non_siliconflow_openai_streaming(monkeypatch):

--- a/backend/test/unit/services/test_run_worker.py
+++ b/backend/test/unit/services/test_run_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+import importlib
 from types import SimpleNamespace
 
 import pytest
@@ -70,6 +71,10 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, run_obj: SimpleNamespace):
         assert message_id == 10
         return SimpleNamespace(content="hello", image_content=None, extra_metadata={})
 
+    async def fake_get_agent_state_view(**kwargs):
+        del kwargs
+        return {"agent_state": None}
+
     async def fake_not_cancelled(self):
         del self
         return False
@@ -78,6 +83,7 @@ def _patch_common(monkeypatch: pytest.MonkeyPatch, run_obj: SimpleNamespace):
     monkeypatch.setattr(run_worker, "_get_run", fake_get_run)
     monkeypatch.setattr(run_worker, "_load_user", fake_load_user)
     monkeypatch.setattr(run_worker, "_load_input_message", fake_load_input_message)
+    monkeypatch.setattr(run_worker, "get_agent_state_view", fake_get_agent_state_view)
     monkeypatch.setattr(run_worker, "mark_run_running", fake_noop)
     monkeypatch.setattr(run_worker, "clear_cancel_signal", fake_noop)
     monkeypatch.setattr(run_worker, "stream_agent_chat", lambda **kwargs: object())
@@ -112,8 +118,8 @@ async def test_process_agent_run_restores_invocation_meta(monkeypatch: pytest.Mo
         del kwargs
         events.append({"run_id": run_id, "event_type": event_type, "payload": payload})
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, kwargs
         terminal_statuses.append(status)
         return run_worker.TerminalTransition(status=status, changed=True)
 
@@ -141,6 +147,108 @@ async def test_process_agent_run_restores_invocation_meta(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_process_agent_run_persists_usage_from_canonical_state(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    run_obj = _build_run()
+    _patch_common(monkeypatch, run_obj)
+    terminal_calls: list[dict] = []
+
+    async def fake_append_event(*args, **kwargs):
+        del args, kwargs
+
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        terminal_calls.append({"run_id": run_id, "status": status, **kwargs})
+        return run_worker.TerminalTransition(status=status, changed=True)
+
+    async def fake_get_agent_state_view(**kwargs):
+        assert kwargs["thread_id"] == "thread-1"
+        assert kwargs["current_user"].uid == "user-1"
+        return {
+            "agent_state": {
+                "token_usage": {
+                    "current_run_id": "run-1",
+                    "run": {
+                        "schema_version": 2,
+                        "models": {"provider:model": {}},
+                        "total": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+                    },
+                }
+            }
+        }
+
+    def fake_stream_agent_chat(**kwargs):
+        del kwargs
+        return _BytesAsyncIter(
+            [
+                (
+                    b'{"status":"agent_state","thread_id":"thread-1","agent_state":{"token_usage":'
+                    b'{"current_run_id":"run-1","run":{"schema_version":2,"models":{"provider:model":{}},'
+                    b'"total":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}}}\n'
+                ),
+                (
+                    b'{"status":"agent_state","thread_id":"child-thread","agent_state":{"token_usage":'
+                    b'{"current_run_id":"run-1","run":{"schema_version":2,"models":{"child:model":{}},'
+                    b'"total":{"input_tokens":999,"output_tokens":1,"total_tokens":1000}}}}}\n'
+                ),
+                (
+                    b'{"status":"agent_state","thread_id":"thread-1","agent_state":{"token_usage":'
+                    b'{"current_run_id":"other-run","run":{"schema_version":2,"models":{"other:model":{}},'
+                    b'"total":{"input_tokens":500,"output_tokens":5,"total_tokens":505}}}}}\n'
+                ),
+                (
+                    b'{"status":"finished","request_id":"req-1","thread_id":"thread-1",'
+                    b'"token_usage":{"schema_version":2,"models":{"terminal:model":{}},'
+                    b'"total":{"input_tokens":700,"output_tokens":7,"total_tokens":707}}}\n'
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(run_worker, "append_run_event", fake_append_event)
+    monkeypatch.setattr(run_worker, "mark_run_terminal", fake_mark_terminal)
+    monkeypatch.setattr(run_worker, "get_agent_state_view", fake_get_agent_state_view)
+    monkeypatch.setattr(run_worker, "stream_agent_chat", fake_stream_agent_chat)
+
+    await run_worker.process_agent_run({"job_try": 1}, "run-1")
+
+    assert terminal_calls[0]["status"] == "completed"
+    assert terminal_calls[0]["token_usage"] == {
+        "schema_version": 2,
+        "models": {"provider:model": {}},
+        "total": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_run_token_usage_from_state_rejects_other_run(monkeypatch: pytest.MonkeyPatch):
+    @asynccontextmanager
+    async def fake_session_ctx():
+        yield object()
+
+    async def fake_get_agent_state_view(**kwargs):
+        del kwargs
+        return {
+            "agent_state": {
+                "token_usage": {
+                    "current_run_id": "old-run",
+                    "run": {"schema_version": 2, "models": {}, "total": {"total_tokens": 99}},
+                }
+            }
+        }
+
+    monkeypatch.setattr(run_worker.pg_manager, "get_async_session_context", fake_session_ctx)
+    monkeypatch.setattr(run_worker, "get_agent_state_view", fake_get_agent_state_view)
+
+    usage = await run_worker._read_run_token_usage_from_state(
+        run_id="run-1",
+        thread_id="thread-1",
+        current_user=SimpleNamespace(uid="user-1"),
+    )
+
+    assert usage is None
+
+
+@pytest.mark.asyncio
 async def test_process_agent_run_publishes_interrupt_after_final_state(monkeypatch: pytest.MonkeyPatch):
     """审批中断必须在最终状态落流后结束，避免前端过早刷新历史。"""
     run_obj = _build_run()
@@ -153,8 +261,8 @@ async def test_process_agent_run_publishes_interrupt_after_final_state(monkeypat
         del run_id, kwargs
         events.append({"event_type": event_type, "payload": payload})
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, kwargs
         terminal_statuses.append(status)
         return run_worker.TerminalTransition(status=status, changed=True)
 
@@ -194,8 +302,8 @@ async def test_process_agent_run_non_retryable_error_marks_failed(monkeypatch: p
         del run_id, payload, kwargs
         events.append(event_type)
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, kwargs
         terminal_statuses.append(status)
         return run_worker.TerminalTransition(status=status, changed=True)
 
@@ -226,8 +334,8 @@ async def test_process_agent_run_retryable_error_retries_then_completes(monkeypa
         del run_id, kwargs
         events.append({"event_type": event_type, "payload": payload})
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, kwargs
         terminal_statuses.append(status)
         return run_worker.TerminalTransition(status=status, changed=True)
 
@@ -259,8 +367,8 @@ async def test_process_agent_run_retryable_error_retries_then_completes(monkeypa
 async def test_finish_run_terminal_loser_does_not_append_end_event(monkeypatch: pytest.MonkeyPatch):
     events: list[tuple[str, dict]] = []
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, status, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, status, kwargs
         return run_worker.TerminalTransition(status="cancelled", changed=False)
 
     async def fake_append_event(run_id: str, event_type: str, payload: dict, **kwargs):
@@ -275,6 +383,7 @@ async def test_finish_run_terminal_loser_does_not_append_end_event(monkeypatch: 
         "completed",
         thread_id="thread-1",
         chunk={"status": "finished"},
+        current_user=SimpleNamespace(uid="user-1"),
     )
 
     assert transition == run_worker.TerminalTransition(status="cancelled", changed=False)
@@ -304,8 +413,8 @@ async def test_process_subagent_run_restores_runtime_context(monkeypatch: pytest
     async def fake_append_event(run_id: str, event_type: str, payload: dict, **kwargs):
         del run_id, event_type, payload, kwargs
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
-        del run_id, error_type, error_message
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        del run_id, kwargs
         terminal_statuses.append(status)
         return run_worker.TerminalTransition(status=status, changed=True)
 
@@ -340,7 +449,7 @@ async def test_process_agent_run_rejects_unknown_run_type(monkeypatch: pytest.Mo
 
     terminal_errors: list[dict] = []
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
+    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None, **kwargs):
         terminal_errors.append(
             {
                 "run_id": run_id,
@@ -385,7 +494,7 @@ async def test_process_agent_run_rejects_invalid_raw_input_message(monkeypatch: 
             extra_metadata={"raw_message": {"type": "human", "content": object()}},
         )
 
-    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None):
+    async def fake_mark_terminal(run_id: str, status: str, error_type=None, error_message=None, **kwargs):
         terminal_errors.append(
             {
                 "run_id": run_id,
@@ -517,6 +626,9 @@ async def test_worker_startup_ensures_builtin_mcp_servers(monkeypatch: pytest.Mo
         del session
         calls.append("init_builtin_skills")
 
+    async def fake_ensure_options_in_db(session):
+        del session
+
     def fake_start_runtime_sync():
         calls.append("start_runtime_sync")
 
@@ -531,6 +643,8 @@ async def test_worker_startup_ensures_builtin_mcp_servers(monkeypatch: pytest.Mo
     monkeypatch.setattr(run_worker, "init_builtin_skills", fake_init_builtin_skills)
     monkeypatch.setattr(run_worker.sys_config, "start_runtime_sync", fake_start_runtime_sync)
     monkeypatch.setattr(run_worker, "recover_pending_dispatches", fake_recover_pending_dispatches)
+    options_module = importlib.import_module("yuxi.config.options")
+    monkeypatch.setattr(options_module, "ensure_options_in_db", fake_ensure_options_in_db)
 
     await run_worker._worker_startup({})
 

--- a/backend/test/unit/services/test_run_worker.py
+++ b/backend/test/unit/services/test_run_worker.py
@@ -249,6 +249,36 @@ async def test_read_run_token_usage_from_state_rejects_other_run(monkeypatch: py
 
 
 @pytest.mark.asyncio
+async def test_finish_run_marks_usage_unavailable_when_state_read_fails(monkeypatch: pytest.MonkeyPatch):
+    terminal_calls: list[dict] = []
+
+    async def fake_read_usage(**kwargs):
+        del kwargs
+        return None
+
+    async def fake_mark_terminal(run_id: str, status: str, **kwargs):
+        terminal_calls.append({"run_id": run_id, "status": status, **kwargs})
+        return run_worker.TerminalTransition(status=status, changed=True)
+
+    async def fake_append_end_event(*args, **kwargs):
+        del args, kwargs
+
+    monkeypatch.setattr(run_worker, "_read_run_token_usage_from_state", fake_read_usage)
+    monkeypatch.setattr(run_worker, "mark_run_terminal", fake_mark_terminal)
+    monkeypatch.setattr(run_worker, "_append_end_event", fake_append_end_event)
+
+    await run_worker._finish_run(
+        "run-1",
+        "completed",
+        thread_id="thread-1",
+        chunk={"status": "finished"},
+        current_user=SimpleNamespace(uid="user-1"),
+    )
+
+    assert terminal_calls[0]["token_usage"] == {"available": False}
+
+
+@pytest.mark.asyncio
 async def test_process_agent_run_publishes_interrupt_after_final_state(monkeypatch: pytest.MonkeyPatch):
     """审批中断必须在最终状态落流后结束，避免前端过早刷新历史。"""
     run_obj = _build_run()

--- a/docs/agents/middleware.md
+++ b/docs/agents/middleware.md
@@ -30,7 +30,7 @@
 | `PatchToolCallsMiddleware` | 修正部分工具调用消息形态，提升工具调用兼容性 |
 | `ModelRetryMiddleware` | 在模型调用失败时按配置重试 |
 | `ImageInputCompatibilityMiddleware` | 仅为 OpenAI Chat Completions 兼容链路桥接 `read_file` 返回的图片；模型明确拒绝图片输入时自动改为 `ocr_parse_file` |
-| `TokenUsageMiddleware` | 在 LangGraph state 写入本轮 token 使用快照，供前端状态面板查看 |
+| `TokenUsageMiddleware` | 在 LangGraph state 写入近似上下文、本次与线程累计的 Provider 实际 token 用量、模型标识和缓存命中率，供前端状态面板查看 |
 
 `SubAgentBackend` 使用同一组核心能力，但不会挂载 `YuxiSubAgentMiddleware`，并额外过滤 `present_artifacts`、`ask_user_question`、`install_skill` 等不适合子智能体直接使用的工具。
 
@@ -80,6 +80,19 @@
 | `summary_l2_trigger_ratio` | L1 后进入 L2 summary 的触发比例，建议 `0.1~1.0`，默认 `0.4` |
 
 触发判断使用 Yuxi 自己的近似 token 计算结果，不使用模型返回的 `usage_metadata.total_tokens` 作为触发依据，避免 provider 的计费口径、累计口径或异常上报导致短对话过早压缩。
+
+## Token 用量统计
+
+`TokenUsageMiddleware` 同时维护两种口径，二者不能混用：
+
+- 近似上下文统计通过 `count_tokens_approximately` 计算，用于上下文窗口、摘要阈值和消息构成展示。
+- 实际用量直接保留主 Agent 模型调用返回的 `AIMessage.usage_metadata`，包括 `input_tokens`、`output_tokens`、`total_tokens`、缓存和推理 token 明细。当前不包含 Summary 中间件内部直接发起的 L2 摘要模型调用，因此尚不能作为完整账单口径。
+
+state 中的实际用量分为 `latest`、`run` 和 `thread`：分别表示最近一次模型调用、当前 AgentRun 累计和当前 LangGraph 线程累计。前端状态面板只读取 state；流式终态 chunk 不携带用量。worker 从当前父线程、`current_run_id` 匹配的 AgentState 提取 `run`，在 Run 进入终态时将该快照写入 `AgentRun.token_usage`。`run.models` 与 `thread.models` 使用 Yuxi `provider_id:model_id` 配置 spec 分桶，并记录 Provider 响应中的实际模型 ID，避免模型切换后把不同模型的 token 混为一组，也避免把 OpenAI 兼容协议类型误当作业务供应商。
+
+每个模型桶独立计算缓存 token 命中率：使用 Provider 明确上报的 `input_token_details.cache_read / input_tokens`；OpenAI `priority` / `flex` service tier 对应识别 `priority_cache_read` / `flex_cache_read`。累计时先汇总该模型已上报缓存明细的输入 token，再计算 `sum(cache_read) / sum(input_tokens)`；缺少缓存读取字段表示 Provider 未上报，不按 0 命中处理。当前 Run 的按模型聚合会在终态事务中写入 `AgentRun.token_usage`，父 Run 与 SubAgent Run 分别保存，不重复合并。
+
+`siliconflow-cn` 与 `siliconflow` 当前返回的 usage 格式与统计契约不一致，暂列入 Token 用量 Provider 黑名单。黑名单模型仍计算近似上下文占用，但不写入最近调用、Run 或线程的 Provider 实际用量聚合。
 
 触发后，中间件先执行 L1 结构精简：在本次模型调用的临时消息视图里截断旧 `write_file`/`edit_file` 工具调用的大参数；`ToolMessage.content` 估算 token 数超过 `summary_tool_result_token_limit` 时，会写入当前 Agent 可见的 `outputs/large_tool_results`，消息内替换为工具名、近似 token 数、完整结果路径和不超过同一 token 上限的预览。未超过该上限的工具结果保持原样。这个步骤不修改 LangGraph state 中的原始消息。
 

--- a/docs/develop-guides/changelog.md
+++ b/docs/develop-guides/changelog.md
@@ -10,7 +10,7 @@
 1. 升级到 v0.7.2 后，管理员此前创建的 stdio MCP 会被禁用，也无法重新启用。请在详情页迁移为 SSE 或 Streamable HTTP，或直接删除；代码内置的系统 stdio MCP 不受影响。
 :::
 
-
+- 完善 Agent Token 用量统计：state 同时保留近似上下文与主 Agent 模型返回的 Provider `usage_metadata`，实际用量拆分为最近调用、当前 Run 和线程累计；前端只读取 state，终态 chunk 不传递用量，worker 在 Run 终态时将父线程中 Run ID 匹配的 state 快照写入 AgentRun。支持 OpenAI priority/flex 缓存明细；L2 摘要内部调用暂未计入完整账单口径。
 - 优化知识库文档列表性能：根目录虚拟目录分组改用部分索引（`idx_kf_kb_parent_segment` 按路径首段聚合），平铺文件筛选与排序用 `idx_kf_kb_parent_flat` 支撑，避免大知识库全表扫描与 46MB 磁盘排序溢出；文件统计聚合结果增加 10 秒 Redis 短缓存，列表、统计、子目录计数与创建人查询并行执行，前端自动刷新轮询间隔同步调整为 10 秒。36 万文件知识库列表接口耗时由约 1.3s 降至约 300ms。
 - 修复 MCP 管理接口可通过 stdio 启动任意本地进程的问题：用户配置仅允许 SSE/Streamable HTTP，运行时拒绝加载历史用户 stdio 记录，系统内置 stdio 的连接参数改为仅由代码维护；前端移除用户 stdio 配置入口，文档补充内置 stdio 的代码添加与验证方式。
 - 工作区新增只读历史对话文件入口 `agents/chats/{thread_id}`，网页以 `YYYY-MM-DD-title` 显示并按日期标题倒序浏览各 thread 的非空 uploads 与 outputs；空目录、无文件对话及 `large_tool_results`、`conversation_history` 等内部中间产物不展示。该目录由 API 虚拟映射，不创建符号链接或复制文件，也不进入当前会话 viewer 与 sandbox 挂载，避免 Agent 读取其他会话历史。面包屑中该目录固定显示为"历史对话"与目录列表一致，多选过滤改用只读路径集合避免逐项查找。

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -312,68 +312,128 @@
             <div class="state-panel-body">
               <section
                 v-if="currentTokenUsage"
-                class="state-section"
-                :class="{ 'is-collapsed': !isStateSectionExpanded('tokenUsage') }"
+                class="state-section token-usage-section"
                 aria-label="上下文使用情况"
               >
                 <button
                   type="button"
-                  class="state-section-header"
-                  :aria-expanded="isStateSectionExpanded('tokenUsage')"
-                  aria-controls="state-section-token-usage"
-                  @click="toggleStateSection('tokenUsage')"
+                  class="token-usage-context-card"
+                  :aria-expanded="isStateSectionExpanded('tokenUsageDetails')"
+                  aria-controls="token-usage-details"
+                  @click="toggleStateSection('tokenUsageDetails')"
                 >
-                  <span class="state-section-label">
-                    <span class="state-section-title">上下文使用</span>
+                  <span class="token-usage-card-topline">
+                    <span class="token-usage-card-title">上下文占用</span>
+                    <span class="token-usage-card-summary">{{ tokenUsageStackHeadLabel }}</span>
                     <ChevronDown
                       :size="15"
                       class="state-section-chevron"
-                      :class="{ 'is-collapsed': !isStateSectionExpanded('tokenUsage') }"
+                      :class="{
+                        'is-collapsed': !isStateSectionExpanded('tokenUsageDetails')
+                      }"
                     />
+                  </span>
+                  <strong class="token-usage-card-percent">{{
+                    tokenUsageHeaderPercentLabel
+                  }}</strong>
+
+                  <span
+                    class="token-usage-context-track"
+                    role="progressbar"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    :aria-valuenow="
+                      tokenUsageContextRatio === null ? undefined : tokenUsageContextRatio * 100
+                    "
+                    :aria-valuetext="tokenUsageContextAriaLabel"
+                  >
+                    <span
+                      class="token-usage-context-fill"
+                      :class="tokenUsageContextTone"
+                      :style="{ width: tokenUsageContextPercent }"
+                    ></span>
+                  </span>
+
+                  <span v-if="hasTokenUsageMetrics" class="token-usage-card-metrics">
+                    <span v-if="tokenUsageRunTotalLabel !== null">
+                      <small>累计 Token 用量</small>
+                      <strong>{{ tokenUsageRunTotalLabel }}</strong>
+                    </span>
+                    <span v-if="tokenUsageCacheHitLabel !== null">
+                      <small>累计缓存命中率</small>
+                      <strong>{{ tokenUsageCacheHitLabel }}</strong>
+                    </span>
                   </span>
                 </button>
                 <div
-                  v-show="isStateSectionExpanded('tokenUsage')"
-                  id="state-section-token-usage"
-                  class="state-section-content"
+                  v-show="isStateSectionExpanded('tokenUsageDetails')"
+                  id="token-usage-details"
+                  class="token-usage-details"
                 >
-                  <div class="token-usage-content">
-                    <div class="token-usage-stack">
-                      <div class="token-usage-stack-head">
-                        <span>{{ tokenUsageHeaderPercentLabel }}</span>
-                        <strong>{{ tokenUsageStackHeadLabel }}</strong>
+                  <div v-if="tokenUsageModelItems.length" class="token-usage-model-list">
+                    <article
+                      v-for="model in tokenUsageModelItems"
+                      :key="model.key"
+                      class="token-usage-model-item"
+                    >
+                      <header class="token-usage-model-header">
+                        <div>
+                          <strong>{{ model.name }}</strong>
+                          <span v-if="model.responseModel">响应 {{ model.responseModel }}</span>
+                        </div>
+                        <span>{{ model.callCount }} 次调用</span>
+                      </header>
+                      <div class="token-usage-model-stats">
+                        <div class="is-io">
+                          <span>输入 / 输出</span>
+                          <strong>{{ model.io }}</strong>
+                        </div>
+                        <div v-if="model.cache" class="is-cache">
+                          <span>缓存</span>
+                          <strong>{{ model.cache }}</strong>
+                        </div>
+                        <div v-if="model.reasoning" class="is-reasoning">
+                          <span>推理</span>
+                          <strong>{{ model.reasoning }}</strong>
+                        </div>
                       </div>
-                      <div class="token-usage-stack-track" aria-label="Token 构成">
-                        <div
-                          v-for="segment in tokenUsageBarSegments"
-                          :key="segment.key"
-                          class="token-usage-stack-segment"
-                          :class="segment.tone"
-                          :style="{ width: segment.percent }"
-                          :title="`${segment.label}: ${segment.valueLabel}`"
-                        ></div>
-                      </div>
-                      <div class="token-usage-stack-legend">
-                        <span
-                          v-for="segment in tokenUsageSegments"
-                          :key="segment.key"
-                          class="token-usage-stack-legend-item"
-                        >
-                          <i :class="segment.tone"></i>
-                          {{ segment.label }} {{ segment.valueLabel }}
-                        </span>
+                    </article>
+                  </div>
+
+                  <div class="token-usage-composition">
+                    <div class="token-usage-detail-heading">
+                      <span>最近上下文构成</span>
+                    </div>
+                    <div class="token-usage-stack-track" aria-label="Token 构成">
+                      <div
+                        v-for="segment in tokenUsageBarSegments"
+                        :key="segment.key"
+                        class="token-usage-stack-segment"
+                        :class="segment.tone"
+                        :style="{ width: segment.percent }"
+                        :title="`${segment.label}: ${segment.valueLabel}`"
+                      ></div>
+                    </div>
+                    <div class="token-usage-composition-list">
+                      <div
+                        v-for="segment in tokenUsageSegments"
+                        :key="segment.key"
+                        class="token-usage-composition-item"
+                      >
+                        <span><i :class="segment.tone"></i>{{ segment.label }}</span>
+                        <strong>{{ segment.valueLabel }}</strong>
                       </div>
                     </div>
+                  </div>
 
-                    <div v-if="tokenUsageMetaRows.length" class="token-usage-breakdown">
-                      <div
-                        v-for="item in tokenUsageMetaRows"
-                        :key="item.key"
-                        class="token-usage-breakdown-row"
-                      >
-                        <span>{{ item.label }}</span>
-                        <strong>{{ item.value }}</strong>
-                      </div>
+                  <div v-if="tokenUsageSupplementRows.length" class="token-usage-supplement">
+                    <div
+                      v-for="item in tokenUsageSupplementRows"
+                      :key="item.key"
+                      class="token-usage-supplement-row"
+                    >
+                      <span>{{ item.label }}</span>
+                      <strong>{{ item.value }}</strong>
                     </div>
                   </div>
                 </div>
@@ -800,7 +860,7 @@ const attachmentInitialFiles = ref([])
 const attachmentInitialFilesKey = ref(0)
 const isRefreshingState = ref(false)
 const collapsedStateSections = reactive({
-  tokenUsage: false,
+  tokenUsageDetails: true,
   todos: false,
   files: false,
   artifacts: false,
@@ -1183,6 +1243,8 @@ const currentAgentState = computed(() => {
   return currentChatId.value ? getThreadState(currentChatId.value)?.agentState || null : null
 })
 const toFiniteNumber = (value) => {
+  if (value === null || value === undefined || value === '' || typeof value === 'boolean')
+    return null
   const numeric = Number(value)
   return Number.isFinite(numeric) ? numeric : null
 }
@@ -1195,6 +1257,10 @@ const formatTokenCount = (value) => {
     return `${(numeric / TOKEN_COUNT_K_UNIT).toFixed(digits).replace(/\.0+$/, '')}k`
   }
   return String(Math.round(numeric))
+}
+const formatTokenRatio = (value) => {
+  const numeric = toFiniteNumber(value)
+  return numeric === null ? '未上报' : `${(Math.max(0, Math.min(numeric, 1)) * 100).toFixed(1)}%`
 }
 const currentTokenUsage = computed(() => {
   const usage = currentAgentState.value?.token_usage
@@ -1313,13 +1379,35 @@ const tokenUsageStackLimit = computed(() => {
   const contextWindow = toFiniteNumber(currentTokenUsage.value?.context_window)
   if (contextWindow && contextWindow > 0) return contextWindow
 
-  return Math.max(tokenUsageStackTotal.value, 1)
+  return null
+})
+const tokenUsageContextRatio = computed(() => {
+  if (tokenUsageStackLimit.value === null) return null
+  return Math.max(0, Math.min(tokenUsageStackTotal.value / tokenUsageStackLimit.value, 1))
 })
 const tokenUsageHeaderPercentLabel = computed(() => {
-  const limit = Math.max(tokenUsageStackLimit.value, 1)
-  const percent = Math.max(0, Math.min((tokenUsageStackTotal.value / limit) * 100, 100))
+  if (tokenUsageContextRatio.value === null) return '--'
+  const percent = tokenUsageContextRatio.value * 100
   if (percent > 0 && percent < 1) return '<1%'
   return `${Math.round(percent)}%`
+})
+const tokenUsageContextPercent = computed(() => {
+  return tokenUsageContextRatio.value === null
+    ? '0%'
+    : `${(tokenUsageContextRatio.value * 100).toFixed(2)}%`
+})
+const tokenUsageContextTone = computed(() => {
+  const ratio = tokenUsageContextRatio.value
+  if (ratio === null) return ''
+  if (ratio >= 0.9) return 'is-danger'
+  if (ratio >= 0.75) return 'is-warning'
+  return ''
+})
+const tokenUsageContextAriaLabel = computed(() => {
+  if (tokenUsageContextRatio.value === null) {
+    return `上下文上限未知，当前估算 ${formatTokenCount(tokenUsageStackTotal.value)} Token`
+  }
+  return `上下文占用 ${tokenUsageHeaderPercentLabel.value}`
 })
 const tokenUsageStackHeadLabel = computed(() => {
   const summaryTriggerTokens = toFiniteNumber(currentTokenUsage.value?.summary_trigger_tokens)
@@ -1328,8 +1416,35 @@ const tokenUsageStackHeadLabel = computed(() => {
   }
   return `${formatTokenCount(tokenUsageStackTotal.value)} Token`
 })
+const tokenUsageRunTotal = computed(() => {
+  const total = toFiniteNumber(currentTokenUsage.value?.thread?.total?.total_tokens)
+  return total === null ? null : Math.max(total, 0)
+})
+const tokenUsageRunTotalLabel = computed(() => {
+  if (tokenUsageRunTotal.value === null) return null
+  return formatTokenCount(tokenUsageRunTotal.value)
+})
+const tokenUsageCacheHitLabel = computed(() => {
+  const models = currentTokenUsage.value?.thread?.models
+  if (!models || typeof models !== 'object' || Object.keys(models).length === 0) return null
+  let observedInputTokens = 0
+  let cacheReadTokens = 0
+  let observedCalls = 0
+  Object.values(models).forEach((bucket) => {
+    if (!bucket || typeof bucket !== 'object') return
+    observedInputTokens += Math.max(toFiniteNumber(bucket.cache_observed_input_tokens) || 0, 0)
+    cacheReadTokens += Math.max(toFiniteNumber(bucket.cache_read_input_tokens) || 0, 0)
+    observedCalls += Math.max(toFiniteNumber(bucket.cache_observed_call_count) || 0, 0)
+  })
+  if (observedCalls <= 0 || observedInputTokens <= 0) return null
+  return formatTokenRatio(cacheReadTokens / observedInputTokens)
+})
+// 旧会话没有累计统计，两个指标都为 null 时隐藏整个指标行
+const hasTokenUsageMetrics = computed(
+  () => tokenUsageRunTotalLabel.value !== null || tokenUsageCacheHitLabel.value !== null
+)
 const tokenUsageBarSegments = computed(() => {
-  const limit = Math.max(tokenUsageStackLimit.value, 1)
+  const limit = tokenUsageStackLimit.value || Math.max(tokenUsageStackTotal.value, 1)
   let remaining = limit
   return tokenUsageSegments.value
     .filter((segment) => segment.key !== 'cut')
@@ -1343,15 +1458,52 @@ const tokenUsageBarSegments = computed(() => {
     })
     .filter((segment) => segment.value > 0 && segment.percent !== '0.00%')
 })
-const tokenUsageMetaRows = computed(() => {
+const tokenUsageModelItems = computed(() => {
+  const usage = currentTokenUsage.value
+  if (!usage) return []
+  const threadUsage = usage.thread && typeof usage.thread === 'object' ? usage.thread : null
+  const models =
+    threadUsage?.models && typeof threadUsage.models === 'object' ? threadUsage.models : {}
+  return Object.entries(models).map(([bucketKey, bucket]) => {
+    const model = bucket?.model && typeof bucket.model === 'object' ? bucket.model : {}
+    const modelUsage = bucket?.usage && typeof bucket.usage === 'object' ? bucket.usage : {}
+    const responseModelIds = Array.isArray(model.response_model_ids)
+      ? [...new Set(model.response_model_ids.filter((item) => typeof item === 'string' && item))]
+      : []
+    const responseModels = responseModelIds.filter((item) => item !== model.configured_model_id)
+    const cacheRatio = toFiniteNumber(bucket?.cache_hit_ratio)
+    const cacheObservedCalls = toFiniteNumber(bucket?.cache_observed_call_count) || 0
+    const reasoning = toFiniteNumber(modelUsage.output_token_details?.reasoning)
+    return {
+      key: bucketKey,
+      name: model.configured_model_spec || bucketKey,
+      responseModel:
+        responseModels.length > 1
+          ? `${responseModels[0]} 等 ${responseModels.length} 个模型`
+          : responseModels[0] || '',
+      callCount: Math.max(toFiniteNumber(bucket?.model_call_count) || 0, 0),
+      io: `${formatTokenCount(modelUsage.input_tokens)} / ${formatTokenCount(modelUsage.output_tokens)}`,
+      cache:
+        cacheObservedCalls === 0
+          ? ''
+          : cacheRatio === null
+            ? formatTokenCount(bucket?.cache_read_input_tokens)
+            : `${formatTokenCount(bucket?.cache_read_input_tokens)} · ${formatTokenRatio(cacheRatio)}`,
+      reasoning: reasoning === null ? '' : formatTokenCount(reasoning)
+    }
+  })
+})
+const tokenUsageSupplementRows = computed(() => {
   const usage = currentTokenUsage.value
   if (!usage) return []
   const rows = []
-  if (toFiniteNumber(usage.context_window)) {
+  const latest = usage.latest && typeof usage.latest === 'object' ? usage.latest : null
+
+  if (latest?.usage && typeof latest.usage === 'object') {
     rows.push({
-      key: 'context',
-      label: '窗口/剩余',
-      value: `${formatTokenCount(usage.context_window)} / ${formatTokenCount(usage.remaining_context_tokens)}`
+      key: 'latestUsage',
+      label: '最近调用',
+      value: `输入 ${formatTokenCount(latest.usage.input_tokens)} · 输出 ${formatTokenCount(latest.usage.output_tokens)}`
     })
   }
   return rows
@@ -4321,32 +4473,246 @@ watch(currentChatId, (threadId, oldThreadId) => {
   text-align: center;
 }
 
-.token-usage-content {
+.token-usage-section {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding-top: 2px;
 }
 
-.token-usage-stack {
+.token-usage-context-card {
+  width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--gray-150);
+  border-radius: 10px;
+  background: var(--gray-0);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--gray-200);
+    background: var(--gray-10);
+
+    .token-usage-card-title,
+    .state-section-chevron {
+      color: var(--gray-900);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--main-200);
+    outline-offset: 2px;
+  }
 }
 
-.token-usage-stack-head {
+.token-usage-card-topline {
   display: flex;
   align-items: center;
+  gap: 8px;
+}
+
+.token-usage-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.token-usage-card-summary {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--gray-500);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.token-usage-card-percent {
+  display: block;
+  color: var(--gray-900);
+  font-size: 24px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.token-usage-context-track {
+  width: 100%;
+  height: 5px;
+  display: block;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--gray-100);
+}
+
+.token-usage-context-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--main-500);
+  transition:
+    width 0.2s ease,
+    background-color 0.2s ease;
+
+  &.is-warning {
+    background: var(--color-warning-500);
+  }
+
+  &.is-danger {
+    background: var(--color-error-500);
+  }
+}
+
+.token-usage-card-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 2px;
+  padding-top: 10px;
+  border-top: 1px solid var(--gray-100);
+}
+
+.token-usage-card-metrics > span {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.token-usage-card-metrics > span + span {
+  padding-left: 12px;
+  border-left: 1px solid var(--gray-150);
+}
+
+.token-usage-card-metrics small {
+  color: var(--gray-500);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.token-usage-card-metrics strong {
+  overflow: hidden;
+  color: var(--gray-900);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.token-usage-details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 2px;
+}
+
+.token-usage-model-list {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--gray-150);
+  border-radius: 9px;
+  overflow: hidden;
+}
+
+.token-usage-model-item {
+  padding: 11px;
+  background: var(--gray-0);
+  border-bottom: 1px solid var(--gray-150);
+}
+
+.token-usage-model-item:last-child {
+  border-bottom: 0;
+}
+
+.token-usage-model-header {
+  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
+  margin-bottom: 10px;
+}
+
+.token-usage-model-header > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.token-usage-model-header strong {
+  overflow: hidden;
+  color: var(--gray-900);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.token-usage-model-header span {
   font-size: 11px;
   color: var(--gray-500);
 }
 
-.token-usage-stack-head strong {
+.token-usage-model-header > span {
+  flex-shrink: 0;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--gray-50);
+}
+
+.token-usage-model-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.token-usage-model-stats > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.token-usage-model-stats span {
+  color: var(--gray-500);
+  font-size: 10px;
+}
+
+.token-usage-model-stats strong {
+  overflow-wrap: anywhere;
   color: var(--gray-900);
-  font-weight: 650;
+  font-size: 12px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
+}
+
+.token-usage-composition {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px;
+  border: 1px solid var(--gray-150);
+  border-radius: 9px;
+  background: var(--gray-0);
+}
+
+.token-usage-detail-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--gray-600);
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .token-usage-stack-track {
@@ -4364,24 +4730,36 @@ watch(currentChatId, (threadId, oldThreadId) => {
   transition: width 0.2s ease;
 }
 
-.token-usage-stack-legend {
+.token-usage-composition-list {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px 10px;
-  font-size: 12px;
-  color: var(--gray-500);
+  gap: 6px 12px;
 }
 
-.token-usage-stack-legend-item {
+.token-usage-composition-item {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  color: var(--gray-500);
+  font-size: 11px;
+}
+
+.token-usage-composition-item > span {
   min-width: 0;
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  line-height: 1.35;
-  white-space: normal;
 }
 
-.token-usage-stack-legend-item i {
+.token-usage-composition-item strong {
+  color: var(--gray-800);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.token-usage-composition-item i {
   width: 7px;
   height: 7px;
   flex-shrink: 0;
@@ -4390,7 +4768,7 @@ watch(currentChatId, (threadId, oldThreadId) => {
 }
 
 .token-usage-stack-segment,
-.token-usage-stack-legend-item i {
+.token-usage-composition-item i {
   &.is-cut {
     background-color: var(--main-500);
     background-image: repeating-linear-gradient(
@@ -4403,23 +4781,23 @@ watch(currentChatId, (threadId, oldThreadId) => {
   }
 
   &.is-messages {
-    background: var(--main-500);
+    background: var(--chart-palette-1);
   }
 
   &.is-tool-messages {
-    background: var(--color-primary-500);
+    background: var(--chart-palette-6);
   }
 
   &.is-summary {
-    background: var(--color-info-500);
+    background: var(--chart-palette-5);
   }
 
   &.is-system {
-    background: var(--color-success-500);
+    background: var(--chart-palette-2);
   }
 
   &.is-tools {
-    background: var(--color-warning-500);
+    background: var(--chart-palette-3);
   }
 
   &.is-overhead {
@@ -4427,37 +4805,46 @@ watch(currentChatId, (threadId, oldThreadId) => {
   }
 }
 
-.token-usage-breakdown {
+.token-usage-supplement {
   display: flex;
   flex-direction: column;
-  gap: 6px 10px;
-  padding-top: 2px;
+  padding: 0 4px;
 }
 
-.token-usage-breakdown-row {
+.token-usage-supplement-row {
   min-width: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 6px;
-  font-size: 12px;
+  gap: 10px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--gray-100);
+  font-size: 11px;
   color: var(--gray-500);
-  flex-wrap: wrap;
 }
 
-.token-usage-breakdown-row span,
-.token-usage-breakdown-row strong {
+.token-usage-supplement-row:last-child {
+  border-bottom: 0;
+}
+
+.token-usage-supplement-row span,
+.token-usage-supplement-row strong {
   min-width: 0;
-  white-space: normal;
 }
 
-.token-usage-breakdown-row strong {
-  flex: 1 1 100%;
+.token-usage-supplement-row strong {
   color: var(--gray-800);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  line-height: 1.35;
-  word-break: break-word;
+  text-align: right;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .token-usage-context-fill,
+  .token-usage-stack-segment,
+  .state-section-chevron {
+    transition: none;
+  }
 }
 
 .todo-panel-list {

--- a/web/src/components/AgentChatComponent.vue
+++ b/web/src/components/AgentChatComponent.vue
@@ -356,8 +356,12 @@
 
                   <span v-if="hasTokenUsageMetrics" class="token-usage-card-metrics">
                     <span v-if="tokenUsageRunTotalLabel !== null">
-                      <small>累计 Token 用量</small>
-                      <strong>{{ tokenUsageRunTotalLabel }}</strong>
+                      <small>当前 Run 累计</small>
+                      <strong>{{ tokenUsageRunTotalLabel }} Token</strong>
+                    </span>
+                    <span v-if="tokenUsageThreadTotalLabel !== null">
+                      <small>当前 Thread 累计</small>
+                      <strong>{{ tokenUsageThreadTotalLabel }} Token</strong>
                     </span>
                     <span v-if="tokenUsageCacheHitLabel !== null">
                       <small>累计缓存命中率</small>
@@ -1417,12 +1421,20 @@ const tokenUsageStackHeadLabel = computed(() => {
   return `${formatTokenCount(tokenUsageStackTotal.value)} Token`
 })
 const tokenUsageRunTotal = computed(() => {
-  const total = toFiniteNumber(currentTokenUsage.value?.thread?.total?.total_tokens)
+  const total = toFiniteNumber(currentTokenUsage.value?.run?.total?.total_tokens)
   return total === null ? null : Math.max(total, 0)
 })
 const tokenUsageRunTotalLabel = computed(() => {
   if (tokenUsageRunTotal.value === null) return null
   return formatTokenCount(tokenUsageRunTotal.value)
+})
+const tokenUsageThreadTotal = computed(() => {
+  const total = toFiniteNumber(currentTokenUsage.value?.thread?.total?.total_tokens)
+  return total === null ? null : Math.max(total, 0)
+})
+const tokenUsageThreadTotalLabel = computed(() => {
+  if (tokenUsageThreadTotal.value === null) return null
+  return formatTokenCount(tokenUsageThreadTotal.value)
 })
 const tokenUsageCacheHitLabel = computed(() => {
   const models = currentTokenUsage.value?.thread?.models
@@ -1441,7 +1453,10 @@ const tokenUsageCacheHitLabel = computed(() => {
 })
 // 旧会话没有累计统计，两个指标都为 null 时隐藏整个指标行
 const hasTokenUsageMetrics = computed(
-  () => tokenUsageRunTotalLabel.value !== null || tokenUsageCacheHitLabel.value !== null
+  () =>
+    tokenUsageRunTotalLabel.value !== null ||
+    tokenUsageThreadTotalLabel.value !== null ||
+    tokenUsageCacheHitLabel.value !== null
 )
 const tokenUsageBarSegments = computed(() => {
   const limit = tokenUsageStackLimit.value || Math.max(tokenUsageStackTotal.value, 1)

--- a/web/src/components/AgentFilePreview.vue
+++ b/web/src/components/AgentFilePreview.vue
@@ -143,7 +143,7 @@
         </div>
       </template>
       <template v-else-if="file?.previewType === 'pdf' && file?.previewUrl">
-        <iframe :src="file.previewUrl" class="pdf-preview" :title="filePath" />
+        <iframe :src="`${file.previewUrl}#view=FitH&toolbar=0`" class="pdf-preview" :title="filePath" />
       </template>
       <template v-else-if="isHtmlFile && htmlPreviewMode === 'render'">
         <iframe
@@ -223,7 +223,7 @@
             </template>
             <template v-else-if="file?.previewType === 'pdf' && file?.previewUrl">
               <iframe
-                :src="file.previewUrl"
+                :src="`${file.previewUrl}#view=FitH&toolbar=0`"
                 class="pdf-preview fullscreen-embed-preview"
                 :title="filePath"
               />

--- a/web/src/components/AgentFilePreview.vue
+++ b/web/src/components/AgentFilePreview.vue
@@ -143,11 +143,7 @@
         </div>
       </template>
       <template v-else-if="file?.previewType === 'pdf' && file?.previewUrl">
-        <iframe
-          :src="`${file.previewUrl}#view=FitH&toolbar=0`"
-          class="pdf-preview"
-          :title="filePath"
-        />
+        <iframe :src="file.previewUrl" class="pdf-preview" :title="filePath" />
       </template>
       <template v-else-if="isHtmlFile && htmlPreviewMode === 'render'">
         <iframe
@@ -227,7 +223,7 @@
             </template>
             <template v-else-if="file?.previewType === 'pdf' && file?.previewUrl">
               <iframe
-                :src="`${file.previewUrl}#view=FitH&toolbar=0`"
+                :src="file.previewUrl"
                 class="pdf-preview fullscreen-embed-preview"
                 :title="filePath"
               />
@@ -271,7 +267,16 @@
 
 <script setup>
 import { computed, onUnmounted, ref, watch } from 'vue'
-import { Code2, Download, Globe, Maximize, PanelRight, FilePen, Save, X } from 'lucide-vue-next'
+import {
+  Code2,
+  Download,
+  Globe,
+  Maximize,
+  PanelRight,
+  FilePen,
+  Save,
+  X
+} from 'lucide-vue-next'
 import hljs from 'highlight.js/lib/common'
 import MarkdownPreview from '@/components/common/MarkdownPreview.vue'
 import FileTypeIcon from '@/components/common/FileTypeIcon.vue'

--- a/web/src/components/AgentFilePreview.vue
+++ b/web/src/components/AgentFilePreview.vue
@@ -143,7 +143,11 @@
         </div>
       </template>
       <template v-else-if="file?.previewType === 'pdf' && file?.previewUrl">
-        <iframe :src="`${file.previewUrl}#view=FitH&toolbar=0`" class="pdf-preview" :title="filePath" />
+        <iframe
+          :src="`${file.previewUrl}#view=FitH&toolbar=0`"
+          class="pdf-preview"
+          :title="filePath"
+        />
       </template>
       <template v-else-if="isHtmlFile && htmlPreviewMode === 'render'">
         <iframe
@@ -267,16 +271,7 @@
 
 <script setup>
 import { computed, onUnmounted, ref, watch } from 'vue'
-import {
-  Code2,
-  Download,
-  Globe,
-  Maximize,
-  PanelRight,
-  FilePen,
-  Save,
-  X
-} from 'lucide-vue-next'
+import { Code2, Download, Globe, Maximize, PanelRight, FilePen, Save, X } from 'lucide-vue-next'
 import hljs from 'highlight.js/lib/common'
 import MarkdownPreview from '@/components/common/MarkdownPreview.vue'
 import FileTypeIcon from '@/components/common/FileTypeIcon.vue'

--- a/web/src/composables/useAgentStreamHandler.js
+++ b/web/src/composables/useAgentStreamHandler.js
@@ -206,6 +206,7 @@ export function useAgentStreamHandler({
             todos: chunk.agent_state?.todos || [],
             uploads: chunk.agent_state?.uploads || []
           })
+          threadState.agentStateRequestVersion = (threadState.agentStateRequestVersion || 0) + 1
           threadState.agentState = chunk.agent_state
         } else {
           console.warn(`${debugPrefix}[agent_state_skip]`, {

--- a/web/test/unit/agentRequestQueue.test.js
+++ b/web/test/unit/agentRequestQueue.test.js
@@ -48,6 +48,26 @@ const createRunStream = ({ threadState, handleStreamChunk, resetOnGoingConv }) =
     streamSmoother: { flushThread: () => {} }
   })
 
+test('agent_state SSE 使在途状态请求失效', () => {
+  const threadState = {
+    agentState: null,
+    agentStateRequestVersion: 4,
+    onGoingConv: { msgChunks: {} }
+  }
+  const { handleStreamChunk } = useAgentStreamHandler({
+    getThreadState: () => threadState,
+    processApprovalInStream: () => false,
+    currentAgentId: { value: 'agent-1' },
+    supportsFiles: { value: false }
+  })
+  const agentState = { token_usage: { measured_at: '2026-08-09T00:00:00Z' } }
+
+  handleStreamChunk({ status: 'agent_state', agent_state: agentState }, 'thread-1')
+
+  assert.deepEqual(threadState.agentState, agentState)
+  assert.equal(threadState.agentStateRequestVersion, 5)
+})
+
 test('run_created 立即完成状态交接并订阅新 Run SSE', async () => {
   const threadState = {
     queuedRequests: [{ request_id: 'request-1', status: 'queued' }],
@@ -58,10 +78,9 @@ test('run_created 立即完成状态交接并订阅新 Run SSE', async () => {
   const calls = []
   const originalStreamRequestEvents = agentApi.streamRequestEvents
   agentApi.streamRequestEvents = async () =>
-    new Response(
-      'event: run_created\ndata: {"run_id":"run-2"}\n\n',
-      { headers: { 'Content-Type': 'text/event-stream' } }
-    )
+    new Response('event: run_created\ndata: {"run_id":"run-2"}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' }
+    })
 
   try {
     const queue = useAgentRequestQueue({
@@ -312,10 +331,9 @@ test('旧 Run 终态清理保留排队 Request SSE', async () => {
   const resetCalls = []
   const originalStreamAgentRunEvents = agentApi.streamAgentRunEvents
   agentApi.streamAgentRunEvents = async () =>
-    new Response(
-      'event: end\ndata: {"run_id":"run-1","payload":{"status":"completed"}}\n\n',
-      { headers: { 'Content-Type': 'text/event-stream' } }
-    )
+    new Response('event: end\ndata: {"run_id":"run-1","payload":{"status":"completed"}}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' }
+    })
 
   try {
     const runStream = createRunStream({


### PR DESCRIPTION
## 变更说明

本 PR 完善 Agent Token 用量统计，使运行状态同时保留近似上下文占用和模型 Provider 返回的实际 Token 用量，并按模型配置分桶记录最近调用、当前 Run 与当前 Thread 的累计数据。

主要改动如下：

- `TokenUsageMiddleware` 记录上下文估算、Provider `usage_metadata`、缓存读取明细和模型身份信息。
- 按配置模型和实际响应模型归集用量，支持 OpenAI priority/flex 缓存字段。
- 在 Agent Run 进入终态时，将当前 Run 的用量快照持久化到 `AgentRun.token_usage`，父 Run 与 SubAgent Run 分别记录。
- Agent Call 在统计完整时返回 OpenAI-compatible `usage`；Provider 未上报、部分上报、统计读取失败或属于明确禁用统计的 Provider 时返回 `null`，避免将未知用量误报为 0。
- 前端 Agent 状态面板展示上下文占用、当前 Run/Thread 累计用量及缓存命中信息。
- 终态流事件不再重复携带用量，前端统一从 Agent state 获取实时数据。

## 验证情况

- 后端相关单元测试：`59 passed`。
- 前端相关 Node 单元测试：`5 passed`。
- 后端 Ruff check 与 format check：通过。
- 前端 ESLint 与 Prettier check：通过。
- `docker compose exec web pnpm run build`：通过，仅有既有的第三方 PURE annotation 和 chunk size 警告。
- `git diff --check origin/main...HEAD`：通过。
- 已完成独立 Code Review，并修复用量读取失败、Provider 缺失/部分上报时被误表示为 0 的问题。

## 界面变更

Agent 状态面板新增以下信息：

- 上下文窗口占用进度。
- 当前 Run 与当前 Thread 的累计 Token 用量。
- 按模型分桶的输入、输出和缓存命中信息。

<img width="2854" height="1134" alt="image" src="https://github.com/user-attachments/assets/6f1c71bd-5242-48a8-967e-b92825c84785" />


本次未新增独立页面或路由。

## 关联事项

无。

## 补充说明

- SiliconFlow 当前返回的 usage 格式不稳定，因此不纳入实际用量累计，并将统计标记为不完整。
- L2 摘要中间件内部的模型调用暂未计入该统计，因此这里的“完整”表示 TokenUsageMiddleware 所观察到的主模型调用均已上报 usage，不代表整个 Agent 执行链路的完整账单。
- 新增 `agent_runs.token_usage` JSONB 字段，通过现有启动时 schema 演进逻辑补齐，不需要手工迁移。

