### PR TITLE
feat: 新增 OrcaRouter 内置模型供应商模板

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,7 @@ YUXI_CORS_ORIGINS=
 # ARK_API_KEY=
 # MINIMAX_API_KEY=  # MiniMax 大模型 https://platform.minimaxi.com/
 # TOGETHER_API_KEY=
+# ORCAROUTER_API_KEY=  # OrcaRouter 路由网关 https://www.orcarouter.ai
 # # endregion model_provider
 
 # Production credentials (required by docker-compose.prod.yml)

--- a/backend/package/yuxi/models/providers/builtin.py
+++ b/backend/package/yuxi/models/providers/builtin.py
@@ -163,6 +163,13 @@ BUILTIN_PROVIDERS: list[dict[str, Any]] = [
         "embedding_models_endpoint": "https://openrouter.ai/api/v1/embeddings/models",
     },
     {
+        "provider_id": "orcarouter",
+        "display_name": "OrcaRouter",
+        "base_url": "https://api.orcarouter.ai/v1",
+        "api_key_env": "ORCAROUTER_API_KEY",
+        "models_endpoint": "https://api.orcarouter.ai/v1/models",
+    },
+    {
         "provider_id": "modelscope",
         "display_name": "ModelScope",
         "base_url": "https://api-inference.modelscope.cn/v1",

--- a/backend/test/unit/services/test_model_provider_service.py
+++ b/backend/test/unit/services/test_model_provider_service.py
@@ -260,6 +260,22 @@ def test_builtin_provider_templates_default_to_openai_provider_type():
     assert all("ollama" not in provider["provider_id"] for provider in BUILTIN_PROVIDERS)
 
 
+def test_builtin_orcarouter_template_is_chat_openai_compatible():
+    orca = next(p for p in BUILTIN_PROVIDERS if p["provider_id"] == "orcarouter")
+    assert orca["display_name"] == "OrcaRouter"
+    assert orca["base_url"] == "https://api.orcarouter.ai/v1"
+    assert orca["api_key_env"] == "ORCAROUTER_API_KEY"
+    assert orca.get("capabilities") in (None, ["chat"])
+    payload = _normalize_payload(
+        {
+            "provider_id": orca["provider_id"],
+            "display_name": orca["display_name"],
+            "base_url": orca["base_url"],
+        }
+    )
+    assert payload["provider_type"] == "openai"
+
+
 @pytest.mark.parametrize(
     ("is_enabled", "api_key", "api_key_env", "expected"),
     [

--- a/docs/develop-guides/decisions/implemented/2026-08-21-orcarouter-builtin-provider.md
+++ b/docs/develop-guides/decisions/implemented/2026-08-21-orcarouter-builtin-provider.md
@@ -1,0 +1,32 @@
+# 新增 OrcaRouter 内置模型供应商模板
+
+状态：implemented
+类型：feature
+Owner：backend/package/yuxi/models/providers/builtin.py
+
+## 问题
+
+内置供应商模板缺少 OrcaRouter 路由网关，用户无法在「模型供应商」页面直接选择 OrcaRouter，需手动填写 Base URL 与模型清单。
+
+## 决策
+
+在 `BUILTIN_PROVIDERS` 中新增 `orcarouter` 模板，镜像 DeepSeek 的 OpenAI 兼容接线：`base_url=https://api.orcarouter.ai/v1`、`api_key_env=ORCAROUTER_API_KEY`、`models_endpoint=/v1/models`。默认 `provider_type=openai`，走既有的 OpenAI 兼容 chat 运行时（`load_chat_model` 的默认分支），无需新增 adapter。
+
+登记点：`builtin.py` 模板条目、`docs/intro/model-config.md` 内置供应商表、`.env.template` 可选密钥注释、unit 测试断言模板可规范化。
+
+## 替代方案
+
+- 新增专用 `provider_type=orcarouter`：OrcaRouter 完全兼容 OpenAI Chat Completions 协议，新增枚举值只会增加校验面（`VALID_PROVIDER_TYPES`）而无行为收益，拒绝。
+- 前端 icon 注册：lobehub 图标库暂无 orca/orcarouter 图标，新增条目会引用不存在的图片，拒绝；走既有 `modelAvatars.default` 兜底。
+
+## 后果
+
+内置模板启动时由 `ensure_builtin_model_providers_in_db` 同步，仅当 provider 不存在时创建，不影响管理员已编辑配置。聊天能力经 OpenAI 兼容运行时支持，远端模型列表由 `/v1/models` 拉取。
+
+## 验证
+
+| 验收主张 | 失败面 | 语义 Owner | 直接证据 / 命令 | 负向案例 | 当前结果 |
+|---|---|---|---|---|---|
+| `orcarouter` 模板存在且可规范化为 openai provider_type | 模板缺字段或校验失败 | `builtin.py` + `service._normalize_payload` | `pytest backend/test/unit/services/test_model_provider_service.py -k orcarouter` | provider_type 非 openai 时测试失败 | Passed |
+| 文档表与 .env 注释同步 | 文档与模板不一致 | `docs/intro/model-config.md`、`.env.template` | `git diff --check` | 表中 provider_id 与代码不符 | Inspected |
+| 真实聊天调用连通 OrcaRouter | 端到端不可用 | `load_chat_model` OpenAI 兼容分支 | 真 key 走 OpenAI 兼容 Chat Completions 请求 | 非 200 响应 | Passed |

--- a/docs/intro/model-config.md
+++ b/docs/intro/model-config.md
@@ -50,6 +50,7 @@
 | MiniMax | `minimax-cn` | chat | `MINIMAX_API_KEY` |
 | MiniMax International | `minimax` | chat | `MINIMAX_API_KEY` |
 | OpenRouter | `openrouter` | chat, embedding | `OPENROUTER_API_KEY` |
+| OrcaRouter | `orcarouter` | chat | `ORCAROUTER_API_KEY` |
 | ModelScope | `modelscope` | chat | `MODELSCOPE_ACCESS_TOKEN` |
 | OpenCode | `opencode` | chat | 无默认环境变量 |
 | OpenCode Go | `opencode-go` | chat | 无默认环境变量 |


### PR DESCRIPTION
## 变更说明

Add [OrcaRouter](https://www.orcarouter.ai) as a built-in model provider template in the model management page. OrcaRouter is an OpenAI-compatible gateway that routes to 150+ frontier models through a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

- 任务类型：`feature`
- 目标：让管理员能在「模型供应商」页面直接选择 OrcaRouter，无需手动填写 Base URL。
- 非目标：不新增 `provider_type` 枚举值（OrcaRouter 完全兼容 OpenAI Chat Completions 协议，走既有 `openai` 运行时）；不新增前端图标（lobehub 图标库暂无 orca/orcarouter 图标，避免引用不存在的图片）。
- substantial / trivial 判断：trivial——纯数据模板登记，无新增运行时逻辑。

## 工程主张与 Owner

- 受影响的工程主张：`BUILTIN_PROVIDERS` 新增 `orcarouter` 模板，启动时由 `ensure_builtin_model_providers_in_db` 同步到数据库（仅当 provider 不存在时创建，不覆盖管理员已编辑配置）。
- Owner / commit point / 观察边界：`backend/package/yuxi/models/providers/builtin.py` 拥有模板定义；`yuxi.models.providers.service._normalize_payload` 负责校验与规范化。
- 决策记录：`docs/develop-guides/decisions/implemented/2026-08-21-orcarouter-builtin-provider.md`

## 验证情况

### `orcarouter` 模板存在且可规范化为 openai provider_type

- 失败面：模板缺字段或校验失败
- 语义 Owner：`builtin.py` + `service._normalize_payload`
- 直接证据 / 命令：`pytest backend/test/unit/services/test_model_provider_service.py -k orcarouter`
- 负向案例：provider_type 非 openai 时测试失败
- 结果：Passed（`test_builtin_orcarouter_template_is_chat_openai_compatible` 通过；同文件 26 个测试全绿）

### 文档表与 .env 注释同步

- 失败面：文档与模板不一致
- 语义 Owner：`docs/intro/model-config.md`、`.env.template`
- 直接证据 / 命令：`git diff --check`、`python3 scripts/verify_engineering_contracts.py`
- 负向案例：表中 provider_id 与代码不符
- 结果：Passed（工程信任检查通过：25 decisions / 66 docs / 24 routers；`python3 -m unittest scripts.test_verify_engineering_contracts` 61 个测试通过）

### 真实聊天调用连通 OrcaRouter

- 失败面：端到端不可用
- 语义 Owner：`load_chat_model` OpenAI 兼容分支
- 直接证据 / 命令：真 key 走 OpenAI 兼容 Chat Completions 请求 `https://api.orcarouter.ai/v1/chat/completions`（model `orcarouter/auto`）
- 负向案例：非 200 响应
- 结果：Passed（HTTP 200，`orcarouter/auto` 路由到真实模型；`GET /v1/models` 返回 209 个模型）

## 简化 / 删除验收

不涉及。

## 独立语义 Review

本变更已在独立工作副本中完整审查：diff 仅新增模板数据、文档行、测试断言和决策记录，无运行时逻辑改动。Review 确认不存在可裁决的替代方案（新增 `provider_type=orcarouter` 枚举无行为收益，仅增加校验面）。

## 未验证范围与风险

- 仓库完整 pytest 套件（依赖 Docker Compose + PostgreSQL/Redis/MinIO + torch）未在本环境运行；已针对改动面运行最小相关 unit（provider service 26 个测试）与工程契约 verifier。
- 真实 HTTP integration（页面保存供应商后走完整链路）未运行，相关风险记录为 `Not run`。
- 前端 icon：未新增 `modelAvatars` 条目，OrcaRouter 卡片复用既有 `default` 兜底图标。

## 事故反馈

不适用。

## 界面变更

不涉及 UI 代码改动（新供应商自动出现在管理页模板列表）。

## 关联事项

无。

## 补充说明

OrcaRouter 兼容 OpenAI Chat Completions 协议，聊天能力经既有 `openai` 运行时支持；远端模型列表由 `/v1/models` 拉取（实测返回 209 个模型）。Disclosure: I'm an engineer on the OrcaRouter team.
