### PR TITLE
fix: 修复macOSx86开发环境pg的bind路径权限导致未初始化数据库的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -401,7 +401,7 @@ services:
     volumes:
       - type: bind
         source: ${YUXI_STATE_DIR:-./docker/volumes}/postgresql
-        target: /var/lib/postgresql/data
+        target: /var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-yuxi} || exit 1"]
       interval: 5s


### PR DESCRIPTION
## 变更说明

Fix PostgreSQL container failing to create the yuxi database on macOS (x86_64) due to bind mount permission issues with Docker Desktop.

## Problem

On macOS Docker Desktop, the postgres container fails to start during first-time deployment. The root cause is a permission mismatch caused by bind mounting directly to /var/lib/postgresql/data:

Docker Desktop's file sharing driver maps the host directory ownership to root or the current macOS user's UID.
PostgreSQL inside the container requires the data directory to be owned by the postgres user (UID 70).
As a result, pg_ctl fails with: FATAL: data directory "/var/lib/postgresql/data" has wrong ownership
The POSTGRES_DB database is never created because the server never starts during initdb.
This causes a cascade failure: dependency failed to start: container pat-postgres-1 is unhealthy

Key error from container logs

FATAL: data directory "/var/lib/postgresql/data" has wrong ownership
HINT: The server must be started by the user that owns the data directory.

FATAL: database "yuxi" does not exist

## Fix

Change the bind mount target from /var/lib/postgresql/data to /var/lib/postgresql (parent directory). This allows the postgres entrypoint script to create the data subdirectory inside the container with the correct ownership, avoiding the macOS bind mount permission mismatch.

Before:
```yaml
volumes:
  type: bind
    source: {YUXI_STATE_DIR:-./docker/volumes}/postgresql
    target: /var/lib/postgresql/data
```

After:
```yaml
volumes:
  type: bind
    source: {YUXI_STATE_DIR:-./docker/volumes}/postgresql
    target: /var/lib/postgresql
```

Bind mount is preserved so host-side access to data files remains available. The directory structure on the host changes slightly — PostgreSQL data files now live under postgresql/data/ instead of postgresql/.

### Environment

macOS (x86_64)
First-time deployment (docker compose up --build -d)
./scripts/init.sh completed successfully before the error

### Closes #995 

