### PR TITLE
fix(sandbox): 主智能体编排期沙盒 idle 超时被误杀，加主动 keepalive 续命

### DIFF
--- a/backend/package/yuxi/agents/backends/sandbox/provider.py
+++ b/backend/package/yuxi/agents/backends/sandbox/provider.py
@@ -209,7 +209,6 @@ class ProvisionerSandboxProvider:
         while not self._stop_event.wait(self._touch_interval_seconds):
             self._keepalive_tick()
 
-
     def get(
         self,
         thread_id: str,

--- a/backend/package/yuxi/agents/backends/sandbox/provider.py
+++ b/backend/package/yuxi/agents/backends/sandbox/provider.py
@@ -112,6 +112,17 @@ class ProvisionerSandboxProvider:
         self._connections: dict[str, SandboxConnection] = {}
         self._last_touch_at: dict[str, float] = {}
         self._touch_interval_seconds = int(os.getenv("SANDBOX_KEEPALIVE_INTERVAL_SECONDS") or 30)
+        # 主动 keepalive：编排型主智能体可能长时间不执行沙盒命令，惰性 touch 会导致
+        # 沙盒 idle 超时被 provisioner 清理，随后 create_if_missing=False 无法重建。
+        self._stop_event = threading.Event()
+        self._keepalive_thread: threading.Thread | None = None
+        if self._touch_interval_seconds > 0:
+            self._keepalive_thread = threading.Thread(
+                target=self._keepalive_loop,
+                name="sandbox-keepalive",
+                daemon=True,
+            )
+            self._keepalive_thread.start()
 
     def _thread_lock(self, cache_key: str) -> threading.Lock:
         with self._lock:
@@ -164,6 +175,40 @@ class ProvisionerSandboxProvider:
         connection.sandbox_url = record.sandbox_url
         connection.generation = record.generation
         return True
+
+    def _keepalive_touch(self, connection: SandboxConnection) -> bool:
+        """仅续命：刷新 provisioner 的活动时间戳，返回沙盒是否仍存活。"""
+        is_alive = self._client.touch(connection.sandbox_id)
+        self._last_touch_at[connection.cache_key] = time.time()
+        return is_alive
+
+    def _keepalive_tick(self) -> None:
+        """单次续命：touch 所有到期活跃沙盒，移除已清理的连接。"""
+        with self._lock:
+            cache_keys = list(self._connections.keys())
+        for cache_key in cache_keys:
+            connection = self._connections.get(cache_key)
+            if connection is None or not self._should_touch(cache_key):
+                continue
+            lock = self._thread_lock(cache_key)
+            with lock:
+                current = self._connections.get(cache_key)
+                if current is None:
+                    continue
+                try:
+                    if not self._keepalive_touch(current):
+                        with self._lock:
+                            self._connections.pop(cache_key, None)
+                            self._last_touch_at.pop(cache_key, None)
+                except Exception:  # noqa: BLE001
+                    # touch 网络抖动保守保留连接，下次 get() 再收敛。
+                    pass
+
+    def _keepalive_loop(self) -> None:
+        """后台线程：定期续命活跃沙盒，避免主智能体编排期(长时间不执行命令)触发 idle 回收。"""
+        while not self._stop_event.wait(self._touch_interval_seconds):
+            self._keepalive_tick()
+
 
     def get(
         self,
@@ -259,6 +304,7 @@ class ProvisionerSandboxProvider:
             self._last_touch_at.pop(cache_key, None)
 
     def shutdown(self) -> None:
+        self._stop_event.set()
         with self._lock:
             connections = list(self._connections.values())
             self._connections.clear()

--- a/backend/test/unit/backends/test_sandbox_backends.py
+++ b/backend/test/unit/backends/test_sandbox_backends.py
@@ -1689,3 +1689,53 @@ def test_workdir_paths_are_workspace_relative_and_reject_symlinks(monkeypatch, t
     (projects / file_id).write_text("file", encoding="utf-8")
     with pytest.raises(ValueError, match="符号链接或非目录组件"):
         paths.user_workdir_host_dir("user-1", f"projects/{file_id}")
+
+
+def test_sandbox_provider_keepalive_touch_reports_liveness_and_updates_timestamp():
+    touched: list[str] = []
+    provider = _make_provider(SimpleNamespace(touch=lambda sandbox_id: touched.append(sandbox_id) or True))
+    cache_key = "user-1::thread-1"
+    connection = SimpleNamespace(sandbox_id="sandbox-1", cache_key=cache_key)
+    provider._connections[cache_key] = connection
+    provider._last_touch_at[cache_key] = 0.0
+
+    assert provider._keepalive_touch(connection) is True
+
+    assert touched == ["sandbox-1"]
+    assert provider._last_touch_at[cache_key] > 0.0
+
+
+def test_sandbox_provider_keepalive_tick_removes_dead_sandbox():
+    provider = _make_provider(SimpleNamespace(touch=lambda _sandbox_id: False))
+    cache_key = "user-1::thread-1"
+    provider._connections[cache_key] = SimpleNamespace(sandbox_id="sandbox-1", cache_key=cache_key)
+    provider._last_touch_at[cache_key] = 0.0
+
+    provider._keepalive_tick()
+
+    assert cache_key not in provider._connections
+    assert cache_key not in provider._last_touch_at
+
+
+def test_sandbox_provider_keepalive_tick_keeps_alive_sandbox():
+    provider = _make_provider(SimpleNamespace(touch=lambda _sandbox_id: True))
+    cache_key = "user-1::thread-1"
+    connection = SimpleNamespace(sandbox_id="sandbox-1", cache_key=cache_key)
+    provider._connections[cache_key] = connection
+    provider._last_touch_at[cache_key] = 0.0
+
+    provider._keepalive_tick()
+
+    assert provider._connections[cache_key] is connection
+    assert provider._last_touch_at[cache_key] > 0.0
+
+
+def test_sandbox_provider_keepalive_tick_skips_fresh_sandbox():
+    provider = _make_provider(SimpleNamespace(touch=lambda _sandbox_id: pytest.fail("fresh sandbox must not be touched")))
+    cache_key = "user-1::thread-1"
+    provider._connections[cache_key] = SimpleNamespace(sandbox_id="sandbox-1", cache_key=cache_key)
+    provider._last_touch_at[cache_key] = 10**12  # 远晚于当前时刻，_should_touch 应返回 False
+
+    provider._keepalive_tick()
+
+    assert cache_key in provider._connections


### PR DESCRIPTION
## 现象

编排型主智能体（如 deep-research）在调度子智能体期间，可能几分钟不执行任何沙盒命令。此时沙盒被 provisioner 按 idle 超时清理，之后主智能体再想用沙盒时 `create_if_missing=False` 无法重建，任务报 `sandbox is unavailable` 直接失败。

## 机理

原实现是「惰性 touch」——只在真正要执行命令前才 `touch` 续命。但主智能体编排期根本不碰沙盒，惰性 touch 永远不触发，沙盒就「安静地」到了 idle 超时被回收。

## 改进方法

在 `ProvisionerSandboxProvider` 里加一个后台 daemon 线程，按 `SANDBOX_KEEPALIVE_INTERVAL_SECONDS`（默认 30s）周期遍历所有活跃沙盒连接，对到期的执行 `touch` 续命；touch 发现沙盒已被清理则移除连接；`shutdown()` 时 `stop_event` 优雅停线程。

## 效果

主智能体即使长时间不执行命令，沙盒也不会被误回收；编排结束后沙盒仍可用，任务不再因 `sandbox is unavailable` 中断。

## 验证

新增 4 个单测：keepalive touch 报活并更新时间戳、tick 移除已清理沙盒、tick 保留存活沙盒、tick 跳过未到期沙盒。