### PR TITLE
fix(models): 净化 invalid_tool_call 与孤儿 ToolMessage，规避 DeepSeek 等接口报错

### DIFF
--- a/backend/package/yuxi/models/chat.py
+++ b/backend/package/yuxi/models/chat.py
@@ -71,9 +71,7 @@ class _InvalidToolCallFilterMixin:
     """在消息发送前清空 invalid_tool_calls，规避 DeepSeek 等接口不支持该变体。"""
 
     def _generate(self, messages, stop=None, run_manager=None, **kwargs):
-        return super()._generate(
-            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
-        )
+        return super()._generate(_sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs)
 
     async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
         return await super()._agenerate(
@@ -81,9 +79,7 @@ class _InvalidToolCallFilterMixin:
         )
 
     def _stream(self, messages, stop=None, run_manager=None, **kwargs):
-        return super()._stream(
-            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
-        )
+        return super()._stream(_sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs)
 
     async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
         async for chunk in super()._astream(

--- a/backend/package/yuxi/models/chat.py
+++ b/backend/package/yuxi/models/chat.py
@@ -3,7 +3,7 @@
 from uuid import uuid4
 
 from langchain.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AIMessageChunk, convert_to_messages
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage, convert_to_messages
 from langchain_openai import ChatOpenAI
 from pydantic import Field, SecretStr
 
@@ -22,6 +22,79 @@ def resolve_chat_model_spec(model_spec: str | None, *, fallback: str | None = No
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
     raise ValueError("model spec 不能为空")
+
+
+def _sanitize_invalid_tool_calls(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """净化消息里的 invalid_tool_call，规避 DeepSeek 等接口的两类报错：
+
+    1. unknown variant invalid_tool_call —— LLM 生成无效工具调用（JSON 参数截断/格式
+       错误）时，LangChain 记录 invalid_tool_call，序列化后以该变体发往模型。
+    2. role='tool' must be a response to a preceding message with 'tool_calls' ——
+       孤儿 ToolMessage（tool_call_id 已无对应 tool_calls）。
+
+    处理：invalid_tool_calls 属性清空、content 数组里的 invalid_tool_call block 转
+    text、孤儿 ToolMessage 删除。
+    """
+    valid_ids: set[str] = set()
+    for message in messages:
+        if not isinstance(message, AIMessage):
+            continue
+        invalid_calls = getattr(message, "invalid_tool_calls", None)
+        if invalid_calls:
+            logger.warning(f"[invalid_tool_call 过滤] 清空 {len(invalid_calls)} 条 invalid_tool_calls")
+            message.invalid_tool_calls = []
+        for tc in message.tool_calls or []:
+            if tc.get("id"):
+                valid_ids.add(tc["id"])
+        if isinstance(message.content, list):
+            new_content = []
+            for block in message.content:
+                if isinstance(block, dict) and block.get("type") == "invalid_tool_call":
+                    name = block.get("name") or "unknown"
+                    error = block.get("error") or "arguments malformed or truncated"
+                    logger.warning(f"[invalid_tool_call 过滤] content 里的 block 转 text: {name}: {error}")
+                    new_content.append({"type": "text", "text": f"[工具调用失败] {name}: {error}"})
+                else:
+                    new_content.append(block)
+            message.content = new_content
+
+    filtered: list[BaseMessage] = []
+    for message in messages:
+        if isinstance(message, ToolMessage) and message.tool_call_id not in valid_ids:
+            logger.warning(f"[invalid_tool_call 过滤] 删除孤儿 ToolMessage: {message.tool_call_id}")
+            continue
+        filtered.append(message)
+    return filtered
+
+
+class _InvalidToolCallFilterMixin:
+    """在消息发送前清空 invalid_tool_calls，规避 DeepSeek 等接口不支持该变体。"""
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return super()._generate(
+            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
+        )
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+        return await super()._agenerate(
+            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
+        )
+
+    def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+        return super()._stream(
+            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
+        )
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        async for chunk in super()._astream(
+            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
+        ):
+            yield chunk
+
+
+def _wrap_model(cls: type) -> type:
+    """动态创建带 invalid_tool_call 过滤的模型子类。"""
+    return type(f"Filtered{cls.__name__}", (_InvalidToolCallFilterMixin, cls), {})
 
 
 def load_chat_model(fully_specified_name: str | None, *, session_id: str | None = None, **kwargs) -> BaseChatModel:
@@ -69,7 +142,7 @@ def load_chat_model(fully_specified_name: str | None, *, session_id: str | None 
     if info.provider_type == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
-        return ChatAnthropic(
+        return _wrap_model(ChatAnthropic)(
             model=info.model_id,
             api_key=SecretStr(api_key),
             base_url=base_url,
@@ -78,13 +151,13 @@ def load_chat_model(fully_specified_name: str | None, *, session_id: str | None 
     if info.provider_type == "gemini":
         from langchain_google_genai import ChatGoogleGenerativeAI
 
-        return ChatGoogleGenerativeAI(
+        return _wrap_model(ChatGoogleGenerativeAI)(
             model=info.model_id,
             google_api_key=SecretStr(api_key),
             **kwargs,
         )
 
-    return ChatCompletionsAdapter(
+    return _wrap_model(ChatCompletionsAdapter)(
         model=info.model_id,
         api_key=SecretStr(api_key),
         base_url=base_url,

--- a/backend/package/yuxi/models/chat.py
+++ b/backend/package/yuxi/models/chat.py
@@ -1,10 +1,9 @@
 """聊天模型加载、供应商协议适配与通用调用入口。"""
 
-from typing import Any
 from uuid import uuid4
 
 from langchain.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage, convert_to_messages
+from langchain_core.messages import AIMessage, AIMessageChunk, convert_to_messages
 from langchain_openai import ChatOpenAI
 from pydantic import Field, SecretStr
 
@@ -23,103 +22,6 @@ def resolve_chat_model_spec(model_spec: str | None, *, fallback: str | None = No
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
     raise ValueError("model spec 不能为空")
-
-
-def _sanitize_invalid_tool_calls(messages: list[BaseMessage]) -> list[BaseMessage]:
-    """净化消息里的 invalid_tool_call，规避 DeepSeek 等接口的两类报错：
-
-    1. unknown variant invalid_tool_call —— LLM 生成无效工具调用（JSON 参数截断/格式
-       错误）时，LangChain 记录 invalid_tool_call，序列化后以该变体发往模型。
-    2. role='tool' must be a response to a preceding message with 'tool_calls' ——
-       孤儿 ToolMessage（tool_call_id 已无对应 tool_calls）。
-
-    处理：invalid_tool_calls 属性清空、additional_kwargs["tool_calls"] 收敛到合法子集、
-    content 数组里的 invalid_tool_call block 转 text、孤儿 ToolMessage 删除。
-
-    返回新消息对象，不原地修改入参：这些消息来自共享的 graph state / checkpoint。
-    """
-    sanitized: list[BaseMessage] = []
-    valid_ids: set[str] = set()
-
-    for message in messages:
-        if not isinstance(message, AIMessage):
-            sanitized.append(message)
-            continue
-
-        valid_calls = list(message.tool_calls or [])
-        message_valid_ids = {tc["id"] for tc in valid_calls if tc.get("id")}
-        valid_ids |= message_valid_ids
-
-        updates: dict[str, Any] = {}
-
-        invalid_calls = getattr(message, "invalid_tool_calls", None)
-        if invalid_calls:
-            logger.warning(f"[invalid_tool_call 过滤] 清空 {len(invalid_calls)} 条 invalid_tool_calls")
-            updates["invalid_tool_calls"] = []
-
-        # additional_kwargs["tool_calls"] 是 OpenAI 响应的原始 wire 表示。langchain_openai
-        # 的 _convert_message_to_dict 在 tool_calls 与 invalid_tool_calls 都为空时会回退用它
-        # 序列化——若不同步收敛，清空解析字段反而会让畸形调用被原样重发。
-        extra_tool_calls = message.additional_kwargs.get("tool_calls")
-        if isinstance(extra_tool_calls, list):
-            kept = [call for call in extra_tool_calls if isinstance(call, dict) and call.get("id") in message_valid_ids]
-            if len(kept) != len(extra_tool_calls):
-                logger.warning(
-                    f"[invalid_tool_call 过滤] additional_kwargs 里移除 "
-                    f"{len(extra_tool_calls) - len(kept)} 条原始 tool_call"
-                )
-                updates["additional_kwargs"] = {**message.additional_kwargs, "tool_calls": kept}
-
-        if isinstance(message.content, list):
-            new_content: list[Any] = []
-            content_changed = False
-            for block in message.content:
-                if isinstance(block, dict) and block.get("type") == "invalid_tool_call":
-                    name = block.get("name") or "unknown"
-                    error = block.get("error") or "arguments malformed or truncated"
-                    logger.warning(f"[invalid_tool_call 过滤] content 里的 block 转 text: {name}: {error}")
-                    new_content.append({"type": "text", "text": f"[工具调用失败] {name}: {error}"})
-                    content_changed = True
-                else:
-                    new_content.append(block)
-            if content_changed:
-                updates["content"] = new_content
-
-        sanitized.append(message.model_copy(update=updates) if updates else message)
-
-    filtered: list[BaseMessage] = []
-    for message in sanitized:
-        if isinstance(message, ToolMessage) and message.tool_call_id not in valid_ids:
-            logger.warning(f"[invalid_tool_call 过滤] 删除孤儿 ToolMessage: {message.tool_call_id}")
-            continue
-        filtered.append(message)
-    return filtered
-
-
-class _InvalidToolCallFilterMixin:
-    """在消息发送前清空 invalid_tool_calls，规避 DeepSeek 等接口不支持该变体。"""
-
-    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
-        return super()._generate(_sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs)
-
-    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
-        return await super()._agenerate(
-            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
-        )
-
-    def _stream(self, messages, stop=None, run_manager=None, **kwargs):
-        return super()._stream(_sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs)
-
-    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
-        async for chunk in super()._astream(
-            _sanitize_invalid_tool_calls(messages), stop=stop, run_manager=run_manager, **kwargs
-        ):
-            yield chunk
-
-
-def _wrap_model(cls: type) -> type:
-    """动态创建带 invalid_tool_call 过滤的模型子类。"""
-    return type(f"Filtered{cls.__name__}", (_InvalidToolCallFilterMixin, cls), {})
 
 
 def load_chat_model(fully_specified_name: str | None, *, session_id: str | None = None, **kwargs) -> BaseChatModel:
@@ -167,7 +69,7 @@ def load_chat_model(fully_specified_name: str | None, *, session_id: str | None 
     if info.provider_type == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
-        return _wrap_model(ChatAnthropic)(
+        return ChatAnthropic(
             model=info.model_id,
             api_key=SecretStr(api_key),
             base_url=base_url,
@@ -176,13 +78,13 @@ def load_chat_model(fully_specified_name: str | None, *, session_id: str | None 
     if info.provider_type == "gemini":
         from langchain_google_genai import ChatGoogleGenerativeAI
 
-        return _wrap_model(ChatGoogleGenerativeAI)(
+        return ChatGoogleGenerativeAI(
             model=info.model_id,
             google_api_key=SecretStr(api_key),
             **kwargs,
         )
 
-    return _wrap_model(ChatCompletionsAdapter)(
+    return ChatCompletionsAdapter(
         model=info.model_id,
         api_key=SecretStr(api_key),
         base_url=base_url,
@@ -217,6 +119,41 @@ def normalize_tool_call_chunks(message: AIMessageChunk) -> None:
         for key in ("name", "id"):
             if tool.get(key) == "":
                 tool[key] = None
+
+
+def _sanitize_wire_invalid_tool_calls(messages: list[dict], originals: list) -> None:
+    """把 wire 消息里来自 invalid_tool_calls 的截断 function 转成失败反馈。
+
+    langchain_openai 把 AIMessage.invalid_tool_calls 序列化成 type:"function"、
+    arguments 为截断 JSON 的 tool_call，DeepSeek 等接口因此报参数解析失败。这里在
+    发送边界按 tool_call id 移除这些截断调用，并在 content 里给模型明确的 text 反馈，
+    而不是发出畸形参数。原始 checkpoint（LangChain 消息对象）不动。
+    """
+    for wire, original in zip(messages, originals, strict=True):
+        if not isinstance(original, AIMessage):
+            continue
+        invalid = list(original.invalid_tool_calls or [])
+        if not invalid:
+            continue
+        invalid_ids = {call.get("id") for call in invalid if call.get("id")}
+        tool_calls = wire.get("tool_calls")
+        if isinstance(tool_calls, list):
+            kept = [call for call in tool_calls if call.get("id") not in invalid_ids]
+            if kept:
+                wire["tool_calls"] = kept
+            else:
+                wire.pop("tool_calls", None)
+        feedback = "；".join(
+            f"[工具调用失败] {call.get('name') or 'unknown'}: {call.get('error') or 'arguments malformed or truncated'}"
+            for call in invalid
+        )
+        content = wire.get("content")
+        if isinstance(content, list):
+            content.append({"type": "text", "text": feedback})
+        elif content:
+            wire["content"] = [{"type": "text", "text": content}, {"type": "text", "text": feedback}]
+        else:
+            wire["content"] = [{"type": "text", "text": feedback}]
 
 
 class ChatCompletionsAdapter(ChatOpenAI):
@@ -260,8 +197,11 @@ class ChatCompletionsAdapter(ChatOpenAI):
     def _get_request_payload(self, input_, *, stop=None, **kwargs):
         """支持推理的供应商在工具续答时接收完整原文。"""
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        if self.preserve_reasoning and "messages" in payload:
-            originals = self._convert_input(input_).to_messages()
+        if "messages" not in payload:
+            return payload
+        originals = self._convert_input(input_).to_messages()
+        _sanitize_wire_invalid_tool_calls(payload["messages"], originals)
+        if self.preserve_reasoning:
             for original, wire in zip(originals, payload["messages"], strict=True):
                 if isinstance(original, AIMessage):
                     content = wire.get("content")

--- a/backend/package/yuxi/models/chat.py
+++ b/backend/package/yuxi/models/chat.py
@@ -1,5 +1,6 @@
 """聊天模型加载、供应商协议适配与通用调用入口。"""
 
+from typing import Any
 from uuid import uuid4
 
 from langchain.chat_models import BaseChatModel
@@ -32,34 +33,62 @@ def _sanitize_invalid_tool_calls(messages: list[BaseMessage]) -> list[BaseMessag
     2. role='tool' must be a response to a preceding message with 'tool_calls' ——
        孤儿 ToolMessage（tool_call_id 已无对应 tool_calls）。
 
-    处理：invalid_tool_calls 属性清空、content 数组里的 invalid_tool_call block 转
-    text、孤儿 ToolMessage 删除。
+    处理：invalid_tool_calls 属性清空、additional_kwargs["tool_calls"] 收敛到合法子集、
+    content 数组里的 invalid_tool_call block 转 text、孤儿 ToolMessage 删除。
+
+    返回新消息对象，不原地修改入参：这些消息来自共享的 graph state / checkpoint。
     """
+    sanitized: list[BaseMessage] = []
     valid_ids: set[str] = set()
+
     for message in messages:
         if not isinstance(message, AIMessage):
+            sanitized.append(message)
             continue
+
+        valid_calls = list(message.tool_calls or [])
+        message_valid_ids = {tc["id"] for tc in valid_calls if tc.get("id")}
+        valid_ids |= message_valid_ids
+
+        updates: dict[str, Any] = {}
+
         invalid_calls = getattr(message, "invalid_tool_calls", None)
         if invalid_calls:
             logger.warning(f"[invalid_tool_call 过滤] 清空 {len(invalid_calls)} 条 invalid_tool_calls")
-            message.invalid_tool_calls = []
-        for tc in message.tool_calls or []:
-            if tc.get("id"):
-                valid_ids.add(tc["id"])
+            updates["invalid_tool_calls"] = []
+
+        # additional_kwargs["tool_calls"] 是 OpenAI 响应的原始 wire 表示。langchain_openai
+        # 的 _convert_message_to_dict 在 tool_calls 与 invalid_tool_calls 都为空时会回退用它
+        # 序列化——若不同步收敛，清空解析字段反而会让畸形调用被原样重发。
+        extra_tool_calls = message.additional_kwargs.get("tool_calls")
+        if isinstance(extra_tool_calls, list):
+            kept = [call for call in extra_tool_calls if isinstance(call, dict) and call.get("id") in message_valid_ids]
+            if len(kept) != len(extra_tool_calls):
+                logger.warning(
+                    f"[invalid_tool_call 过滤] additional_kwargs 里移除 "
+                    f"{len(extra_tool_calls) - len(kept)} 条原始 tool_call"
+                )
+                updates["additional_kwargs"] = {**message.additional_kwargs, "tool_calls": kept}
+
         if isinstance(message.content, list):
-            new_content = []
+            new_content: list[Any] = []
+            content_changed = False
             for block in message.content:
                 if isinstance(block, dict) and block.get("type") == "invalid_tool_call":
                     name = block.get("name") or "unknown"
                     error = block.get("error") or "arguments malformed or truncated"
                     logger.warning(f"[invalid_tool_call 过滤] content 里的 block 转 text: {name}: {error}")
                     new_content.append({"type": "text", "text": f"[工具调用失败] {name}: {error}"})
+                    content_changed = True
                 else:
                     new_content.append(block)
-            message.content = new_content
+            if content_changed:
+                updates["content"] = new_content
+
+        sanitized.append(message.model_copy(update=updates) if updates else message)
 
     filtered: list[BaseMessage] = []
-    for message in messages:
+    for message in sanitized:
         if isinstance(message, ToolMessage) and message.tool_call_id not in valid_ids:
             logger.warning(f"[invalid_tool_call 过滤] 删除孤儿 ToolMessage: {message.tool_call_id}")
             continue

--- a/backend/package/yuxi/models/chat.py
+++ b/backend/package/yuxi/models/chat.py
@@ -121,41 +121,6 @@ def normalize_tool_call_chunks(message: AIMessageChunk) -> None:
                 tool[key] = None
 
 
-def _sanitize_wire_invalid_tool_calls(messages: list[dict], originals: list) -> None:
-    """把 wire 消息里来自 invalid_tool_calls 的截断 function 转成失败反馈。
-
-    langchain_openai 把 AIMessage.invalid_tool_calls 序列化成 type:"function"、
-    arguments 为截断 JSON 的 tool_call，DeepSeek 等接口因此报参数解析失败。这里在
-    发送边界按 tool_call id 移除这些截断调用，并在 content 里给模型明确的 text 反馈，
-    而不是发出畸形参数。原始 checkpoint（LangChain 消息对象）不动。
-    """
-    for wire, original in zip(messages, originals, strict=True):
-        if not isinstance(original, AIMessage):
-            continue
-        invalid = list(original.invalid_tool_calls or [])
-        if not invalid:
-            continue
-        invalid_ids = {call.get("id") for call in invalid if call.get("id")}
-        tool_calls = wire.get("tool_calls")
-        if isinstance(tool_calls, list):
-            kept = [call for call in tool_calls if call.get("id") not in invalid_ids]
-            if kept:
-                wire["tool_calls"] = kept
-            else:
-                wire.pop("tool_calls", None)
-        feedback = "；".join(
-            f"[工具调用失败] {call.get('name') or 'unknown'}: {call.get('error') or 'arguments malformed or truncated'}"
-            for call in invalid
-        )
-        content = wire.get("content")
-        if isinstance(content, list):
-            content.append({"type": "text", "text": feedback})
-        elif content:
-            wire["content"] = [{"type": "text", "text": content}, {"type": "text", "text": feedback}]
-        else:
-            wire["content"] = [{"type": "text", "text": feedback}]
-
-
 class ChatCompletionsAdapter(ChatOpenAI):
     """在解析边界保留扩展字段，HTTP、重试和工具绑定由上游负责。"""
 
@@ -285,6 +250,41 @@ def select_model(model_spec: str, **kwargs) -> LangChainChatAdapter:
         base_url=info.base_url,
         info={"provider_type": info.provider_type, "provider_id": info.provider_id},
     )
+
+
+def _sanitize_wire_invalid_tool_calls(messages: list[dict], originals: list) -> None:
+    """把 wire 消息里来自 invalid_tool_calls 的截断 function 转成失败反馈。
+
+    langchain_openai 把 AIMessage.invalid_tool_calls 序列化成 type:"function"、
+    arguments 为截断 JSON 的 tool_call，DeepSeek 等接口因此报参数解析失败。这里在
+    发送边界按 tool_call id 移除这些截断调用，并在 content 里给模型明确的 text 反馈，
+    而不是发出畸形参数。原始 checkpoint（LangChain 消息对象）不动。
+    """
+    for wire, original in zip(messages, originals, strict=True):
+        if not isinstance(original, AIMessage):
+            continue
+        invalid = list(original.invalid_tool_calls or [])
+        if not invalid:
+            continue
+        invalid_ids = {call.get("id") for call in invalid if call.get("id")}
+        tool_calls = wire.get("tool_calls")
+        if isinstance(tool_calls, list):
+            kept = [call for call in tool_calls if call.get("id") not in invalid_ids]
+            if kept:
+                wire["tool_calls"] = kept
+            else:
+                wire.pop("tool_calls", None)
+        feedback = "；".join(
+            f"[工具调用失败] {call.get('name') or 'unknown'}: {call.get('error') or 'arguments malformed or truncated'}"
+            for call in invalid
+        )
+        content = wire.get("content")
+        if isinstance(content, list):
+            content.append({"type": "text", "text": feedback})
+        elif content:
+            wire["content"] = [{"type": "text", "text": content}, {"type": "text", "text": feedback}]
+        else:
+            wire["content"] = [{"type": "text", "text": feedback}]
 
 
 if __name__ == "__main__":

--- a/backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py
+++ b/backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py
@@ -1,157 +1,178 @@
-"""invalid_tool_call 净化的 wire payload 回归测试。
+"""invalid_tool_call 窄方案：在 ChatCompletionsAdapter 发送边界净化 wire 载荷。
 
-净化必须落在「真正发给供应商的载荷」上：只清空解析字段(invalid_tool_calls)不够，
-langchain_openai 在 tool_calls 与 invalid_tool_calls 都为空时会回退使用
-additional_kwargs["tool_calls"]，把截断参数的调用原样重发。
+langchain_openai 把 AIMessage.invalid_tool_calls 序列化成 type:"function"、arguments
+为截断 JSON 的 tool_call，DeepSeek 等接口因此报参数解析失败。窄方案在
+ChatCompletionsAdapter._get_request_payload 里按 id 移除这些截断调用，并在 content
+里给模型明确的 text 反馈，覆盖同步/异步/流式/非流式四条路径；不改 Anthropic/Gemini，
+不删孤儿 ToolMessage（按根因单独处理），原始 checkpoint 消息对象不动。
 """
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_openai.chat_models.base import _convert_message_to_dict
+from langchain_core.messages import AIMessage, HumanMessage, InvalidToolCall
+from pydantic import SecretStr
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 
-from yuxi.models.chat import _sanitize_invalid_tool_calls
+from yuxi.models.chat import ChatCompletionsAdapter, _sanitize_wire_invalid_tool_calls
 
 
-def _malformed_raw_call(call_id: str = "call-bad") -> dict:
-    """OpenAI 响应里的原始工具调用：arguments 被截断。"""
-    return {
-        "id": call_id,
-        "type": "function",
-        "function": {"name": "kbs_search", "arguments": '{"query":'},
-    }
-
-
-def _valid_raw_call(call_id: str = "call-good") -> dict:
-    return {
-        "id": call_id,
-        "type": "function",
-        "function": {"name": "kbs_search", "arguments": '{"query": "ok"}'},
-    }
-
-
-def _wire_tool_calls(messages) -> list[dict]:
-    """把消息翻译成供应商实际收到的 tool_calls 载荷。"""
-    payloads = [_convert_message_to_dict(message) for message in messages]
-    return [call for payload in payloads for call in (payload.get("tool_calls") or [])]
-
-
-def test_pure_invalid_call_is_not_resent_on_the_wire():
-    """只有无效调用时，净化后不得再发出该调用（否则请求有 tool_calls 却没有工具响应）。"""
-    message = AIMessage(
-        content="",
-        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
-        invalid_tool_calls=[
-            {"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "Unterminated string"}
-        ],
+def _adapter() -> ChatCompletionsAdapter:
+    return ChatCompletionsAdapter(
+        model="deepseek-chat",
+        api_key=SecretStr("test-key"),
+        base_url="http://test.local/v1",
     )
 
-    sanitized = _sanitize_invalid_tool_calls([message])
 
-    assert _wire_tool_calls(sanitized) == []
-    assert sanitized[0].invalid_tool_calls == []
-
-
-def test_mixed_valid_and_invalid_keeps_only_valid_call_on_the_wire():
-    """有效/无效混合时，wire payload 只保留有效调用。"""
-    message = AIMessage(
-        content="",
-        # 真实解析结果：合法调用进入 tool_calls，原始 wire 表示完整保留在 additional_kwargs。
-        tool_calls=[{"id": "call-good", "name": "kbs_search", "args": {"query": "ok"}, "type": "tool_call"}],
-        additional_kwargs={"tool_calls": [_malformed_raw_call(), _valid_raw_call()]},
-        invalid_tool_calls=[
-            {"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "Unterminated string"}
-        ],
-    )
-
-    sanitized = _sanitize_invalid_tool_calls([message])
-
-    wire_calls = _wire_tool_calls(sanitized)
-    assert [call["id"] for call in wire_calls] == ["call-good"]
-    assert wire_calls[0]["function"]["arguments"] == '{"query": "ok"}'
+def _invalid_call() -> InvalidToolCall:
+    return InvalidToolCall(name="kbs_search", args='{"query":', id="call-bad", error="Unterminated string")
 
 
-def test_sanitize_does_not_mutate_shared_state_messages():
-    """不得原地修改入参：这些消息来自共享 graph state / checkpoint。"""
-    raw_calls = [_malformed_raw_call()]
-    message = AIMessage(
-        content="",
-        additional_kwargs={"tool_calls": raw_calls},
-        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
-    )
-
-    sanitized = _sanitize_invalid_tool_calls([message])
-
-    assert sanitized[0] is not message
-    assert message.invalid_tool_calls  # 原始对象保持不变
-    assert message.additional_kwargs["tool_calls"] == raw_calls
-
-
-def test_orphan_tool_message_is_dropped_with_its_call():
-    """无效调用的配对被删除后，请求里不得残留孤儿 ToolMessage。"""
-    assistant = AIMessage(
-        content="",
-        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
-        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
-    )
-    orphan = ToolMessage(content="tool ran anyway", tool_call_id="call-bad")
-
-    sanitized = _sanitize_invalid_tool_calls([HumanMessage(content="hi"), assistant, orphan])
-
-    assert [type(message).__name__ for message in sanitized] == ["HumanMessage", "AIMessage"]
-    assert _wire_tool_calls(sanitized) == []
-
-
-def test_content_invalid_block_becomes_text_without_invalid_variant_on_the_wire():
-    """content 数组里的 invalid_tool_call block 必须转文本，wire 上不出现该变体。"""
-    message = AIMessage(
-        content=[
-            {"type": "text", "text": "先查询"},
-            {"type": "invalid_tool_call", "name": "kbs_search", "error": "arguments malformed"},
-        ],
-    )
-
-    sanitized = _sanitize_invalid_tool_calls([message])
-
-    payload = _convert_message_to_dict(sanitized[0])
-    assert payload["content"] == [
-        {"type": "text", "text": "先查询"},
-        {"type": "text", "text": "[工具调用失败] kbs_search: arguments malformed"},
+def _messages_with_invalid() -> list:
+    return [
+        HumanMessage(content="hi"),
+        AIMessage(content="", invalid_tool_calls=[_invalid_call()]),
     ]
 
 
+# ---- 单元：wire 净化函数 ----
+
+
+def test_pure_invalid_call_is_removed_and_feedback_added():
+    wire = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"type": "function", "id": "call-bad", "function": {"name": "kbs_search", "arguments": '{"query":'}}
+            ],
+        },
+    ]
+    originals = [
+        HumanMessage(content="hi"),
+        AIMessage(content="", invalid_tool_calls=[_invalid_call()]),
+    ]
+
+    _sanitize_wire_invalid_tool_calls(wire, originals)
+
+    assert "tool_calls" not in wire[1]
+    assert wire[1]["content"] == [{"type": "text", "text": "[工具调用失败] kbs_search: Unterminated string"}]
+
+
+def test_mixed_keeps_valid_call_and_adds_feedback():
+    wire = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call-good",
+                    "function": {"name": "kbs_search", "arguments": '{"query": "ok"}'},
+                },
+                {"type": "function", "id": "call-bad", "function": {"name": "kbs_search", "arguments": '{"query":'}},
+            ],
+        },
+    ]
+    originals = [
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "call-good", "name": "kbs_search", "args": {"query": "ok"}, "type": "tool_call"}],
+            invalid_tool_calls=[_invalid_call()],
+        ),
+    ]
+
+    _sanitize_wire_invalid_tool_calls(wire, originals)
+
+    assert [call["id"] for call in wire[0]["tool_calls"]] == ["call-good"]
+    assert wire[0]["content"] == [{"type": "text", "text": "[工具调用失败] kbs_search: Unterminated string"}]
+
+
+def test_no_invalid_call_leaves_wire_unchanged():
+    wire = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "id": "call-good",
+                    "function": {"name": "kbs_search", "arguments": '{"query": "ok"}'},
+                }
+            ],
+        }
+    ]
+    originals = [
+        AIMessage(
+            content="",
+            tool_calls=[{"id": "call-good", "name": "kbs_search", "args": {"query": "ok"}, "type": "tool_call"}],
+        ),
+    ]
+    snapshot = json.loads(json.dumps(wire))
+
+    _sanitize_wire_invalid_tool_calls(wire, originals)
+
+    assert wire == snapshot
+
+
+# ---- 集成：真实 adapter + mock HTTP，捕获请求体 ----
+
+
+def _assert_body_has_no_invalid_tool_call(request) -> None:
+    body = json.loads(request.content)
+    assistant = body["messages"][1]
+    # 截断 function 已移除，换成 text 反馈
+    assert "tool_calls" not in assistant
+    assert assistant["content"] == [{"type": "text", "text": "[工具调用失败] kbs_search: Unterminated string"}]
+
+
+def _ok_response() -> dict:
+    return {
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _stream_response() -> str:
+    return 'data: {"choices":[{"delta":{"content":"ok"},"index":0}]}\n\ndata: [DONE]\n\n'
+
+
+def test_invoke_sanitizes_request_body(httpx_mock):
+    httpx_mock.add_response(url="http://test.local/v1/chat/completions", json=_ok_response())
+
+    _adapter().invoke(_messages_with_invalid())
+
+    _assert_body_has_no_invalid_tool_call(httpx_mock.get_request())
+
+
 @pytest.mark.asyncio
-async def test_stream_entry_sanitizes_before_sending(monkeypatch):
-    """流式入口同样在发送前净化，而不是只在 _generate 上生效。"""
-    from yuxi.models.chat import _wrap_model
+async def test_ainvoke_sanitizes_request_body(httpx_mock):
+    httpx_mock.add_response(url="http://test.local/v1/chat/completions", json=_ok_response())
 
-    captured: dict = {}
+    await _adapter().ainvoke(_messages_with_invalid())
 
-    class _FakeChatModel:
-        def _stream(self, messages, stop=None, run_manager=None, **kwargs):
-            captured["messages"] = messages
-            return iter([])
+    _assert_body_has_no_invalid_tool_call(httpx_mock.get_request())
 
-        async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
-            captured["messages"] = messages
-            if False:  # pragma: no cover - 生成器语义
-                yield None
 
-    wrapped = _wrap_model(_FakeChatModel)()
-    message = AIMessage(
-        content="",
-        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
-        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
-    )
+def test_stream_sanitizes_request_body(httpx_mock):
+    httpx_mock.add_response(url="http://test.local/v1/chat/completions", text=_stream_response())
 
-    list(wrapped._stream([message]))
-    assert _wire_tool_calls(captured["messages"]) == []
+    list(_adapter().stream(_messages_with_invalid()))
 
-    async for _ in wrapped._astream([message]):
+    _assert_body_has_no_invalid_tool_call(httpx_mock.get_request())
+
+
+@pytest.mark.asyncio
+async def test_astream_sanitizes_request_body(httpx_mock):
+    httpx_mock.add_response(url="http://test.local/v1/chat/completions", text=_stream_response())
+
+    async for _ in _adapter().astream(_messages_with_invalid()):
         pass
-    assert _wire_tool_calls(captured["messages"]) == []
+
+    _assert_body_has_no_invalid_tool_call(httpx_mock.get_request())

--- a/backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py
+++ b/backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py
@@ -1,0 +1,157 @@
+"""invalid_tool_call 净化的 wire payload 回归测试。
+
+净化必须落在「真正发给供应商的载荷」上：只清空解析字段(invalid_tool_calls)不够，
+langchain_openai 在 tool_calls 与 invalid_tool_calls 都为空时会回退使用
+additional_kwargs["tool_calls"]，把截断参数的调用原样重发。
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_openai.chat_models.base import _convert_message_to_dict
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from yuxi.models.chat import _sanitize_invalid_tool_calls
+
+
+def _malformed_raw_call(call_id: str = "call-bad") -> dict:
+    """OpenAI 响应里的原始工具调用：arguments 被截断。"""
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "kbs_search", "arguments": '{"query":'},
+    }
+
+
+def _valid_raw_call(call_id: str = "call-good") -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "kbs_search", "arguments": '{"query": "ok"}'},
+    }
+
+
+def _wire_tool_calls(messages) -> list[dict]:
+    """把消息翻译成供应商实际收到的 tool_calls 载荷。"""
+    payloads = [_convert_message_to_dict(message) for message in messages]
+    return [call for payload in payloads for call in (payload.get("tool_calls") or [])]
+
+
+def test_pure_invalid_call_is_not_resent_on_the_wire():
+    """只有无效调用时，净化后不得再发出该调用（否则请求有 tool_calls 却没有工具响应）。"""
+    message = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
+        invalid_tool_calls=[
+            {"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "Unterminated string"}
+        ],
+    )
+
+    sanitized = _sanitize_invalid_tool_calls([message])
+
+    assert _wire_tool_calls(sanitized) == []
+    assert sanitized[0].invalid_tool_calls == []
+
+
+def test_mixed_valid_and_invalid_keeps_only_valid_call_on_the_wire():
+    """有效/无效混合时，wire payload 只保留有效调用。"""
+    message = AIMessage(
+        content="",
+        # 真实解析结果：合法调用进入 tool_calls，原始 wire 表示完整保留在 additional_kwargs。
+        tool_calls=[{"id": "call-good", "name": "kbs_search", "args": {"query": "ok"}, "type": "tool_call"}],
+        additional_kwargs={"tool_calls": [_malformed_raw_call(), _valid_raw_call()]},
+        invalid_tool_calls=[
+            {"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "Unterminated string"}
+        ],
+    )
+
+    sanitized = _sanitize_invalid_tool_calls([message])
+
+    wire_calls = _wire_tool_calls(sanitized)
+    assert [call["id"] for call in wire_calls] == ["call-good"]
+    assert wire_calls[0]["function"]["arguments"] == '{"query": "ok"}'
+
+
+def test_sanitize_does_not_mutate_shared_state_messages():
+    """不得原地修改入参：这些消息来自共享 graph state / checkpoint。"""
+    raw_calls = [_malformed_raw_call()]
+    message = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": raw_calls},
+        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
+    )
+
+    sanitized = _sanitize_invalid_tool_calls([message])
+
+    assert sanitized[0] is not message
+    assert message.invalid_tool_calls  # 原始对象保持不变
+    assert message.additional_kwargs["tool_calls"] == raw_calls
+
+
+def test_orphan_tool_message_is_dropped_with_its_call():
+    """无效调用的配对被删除后，请求里不得残留孤儿 ToolMessage。"""
+    assistant = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
+        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
+    )
+    orphan = ToolMessage(content="tool ran anyway", tool_call_id="call-bad")
+
+    sanitized = _sanitize_invalid_tool_calls([HumanMessage(content="hi"), assistant, orphan])
+
+    assert [type(message).__name__ for message in sanitized] == ["HumanMessage", "AIMessage"]
+    assert _wire_tool_calls(sanitized) == []
+
+
+def test_content_invalid_block_becomes_text_without_invalid_variant_on_the_wire():
+    """content 数组里的 invalid_tool_call block 必须转文本，wire 上不出现该变体。"""
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "先查询"},
+            {"type": "invalid_tool_call", "name": "kbs_search", "error": "arguments malformed"},
+        ],
+    )
+
+    sanitized = _sanitize_invalid_tool_calls([message])
+
+    payload = _convert_message_to_dict(sanitized[0])
+    assert payload["content"] == [
+        {"type": "text", "text": "先查询"},
+        {"type": "text", "text": "[工具调用失败] kbs_search: arguments malformed"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_entry_sanitizes_before_sending(monkeypatch):
+    """流式入口同样在发送前净化，而不是只在 _generate 上生效。"""
+    from yuxi.models.chat import _wrap_model
+
+    captured: dict = {}
+
+    class _FakeChatModel:
+        def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+            captured["messages"] = messages
+            return iter([])
+
+        async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+            captured["messages"] = messages
+            if False:  # pragma: no cover - 生成器语义
+                yield None
+
+    wrapped = _wrap_model(_FakeChatModel)()
+    message = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [_malformed_raw_call()]},
+        invalid_tool_calls=[{"id": "call-bad", "name": "kbs_search", "args": '{"query":', "error": "bad"}],
+    )
+
+    list(wrapped._stream([message]))
+    assert _wire_tool_calls(captured["messages"]) == []
+
+    async for _ in wrapped._astream([message]):
+        pass
+    assert _wire_tool_calls(captured["messages"]) == []

--- a/docs/develop-guides/decisions/implemented/2026-09-10-model-input-invalid-tool-call-sanitize.md
+++ b/docs/develop-guides/decisions/implemented/2026-09-10-model-input-invalid-tool-call-sanitize.md
@@ -1,4 +1,4 @@
-# 模型输入净化：invalid_tool_call 必须落在 wire payload 上
+# 模型输入净化：invalid_tool_call 的截断 function 在发送边界降级为失败反馈
 
 状态：implemented
 类型：bug-fix
@@ -6,41 +6,40 @@ Owner：backend/package/yuxi/models/chat.py
 
 ## 问题
 
-DeepSeek 等接口对两类消息报错并中断整轮：
+模型生成无效工具调用（JSON 参数截断/格式错）时，LangChain 把它记在 `AIMessage.invalid_tool_calls`。`langchain_openai` 序列化时把它转成 `type:"function"`、`arguments` 为截断 JSON 的 `tool_call`，DeepSeek 等接口因参数不合法报错并中断整轮。
 
-1. `unknown variant invalid_tool_call`：模型生成的工具调用参数被截断/格式错误时，LangChain 记录 `invalid_tool_calls`，序列化后以该变体发往模型。
-2. `role='tool' must be a response to a preceding message with 'tool_calls'`：孤儿 `ToolMessage`（`tool_call_id` 已无对应 `tool_calls`）。
+## 根因澄清（对上一版假设的修正）
 
-只清空 `invalid_tool_calls` 解析字段并不能解决第 1 类：`langchain_openai` 的 `_convert_message_to_dict` 在 `tool_calls` 与 `invalid_tool_calls` **都为空**时会回退使用 `additional_kwargs["tool_calls"]`（OpenAI 响应的原始 wire 表示），把同一条截断参数的调用原样重发；而配对 `ToolMessage` 已被过滤删除，形成「有 tool_calls、无工具响应」的非法请求。
+初版把现象归为「`invalid_tool_calls` 序列化成 `invalid_tool_call` 变体」，并为此清空解析字段、收敛 `additional_kwargs`、删孤儿 `ToolMessage`、动态包装四个入口。实测 `langchain_openai` 1.6.0 的真实序列化推翻了该假设：
+
+- `AIMessage.invalid_tool_calls` 经 `_lc_invalid_tool_call_to_openai_tool_call` 转成 `type:"function"`，**不是** `invalid_tool_call` 变体；真正的问题是 `arguments` 截断导致参数解析失败。
+- content 数组里的 `{"type":"invalid_tool_call"}` block 在 `_convert_from_v1_to_chat_completions` 里已被丢弃，不会泄漏到 wire。
+- 孤儿 `ToolMessage` 的根因在历史裁剪/恢复/消息组装，不是发送边界能安全修复的。
 
 ## 决策
 
-净化必须作用在最终发送载荷上，并保持解析表示与原始表示一致：
+收窄为**只在 Chat Completions 发送边界**处理「截断 function」：`ChatCompletionsAdapter._get_request_payload` 里用原始消息（`invalid_tool_calls` 的 id）对账 wire 载荷，按 id 移除这些截断 `tool_calls`，并在 content 里追加 text 反馈「`[工具调用失败] name: error`」——给模型明确的失败反馈，而不是发出畸形参数。
 
-- 清空 `invalid_tool_calls`；
-- 把 `additional_kwargs["tool_calls"]` 收敛为「id 在合法 `tool_calls` 内」的子集（无合法调用时即为空列表，阻断 `_convert_message_to_dict` 的回退路径）；
-- content 数组里的 `invalid_tool_call` block 转文本；
-- 删除 `tool_call_id` 不在任何合法 `tool_calls` 内的孤儿 `ToolMessage`。
-
-净化返回**新的消息对象**，不原地修改入参——这些对象来自共享的 graph state 与 checkpoint。`_InvalidToolCallFilterMixin` 在 `_generate/_agenerate/_stream/_astream` 四个入口发送前统一调用。
+- 只影响 `ChatCompletionsAdapter`（OpenAI 兼容协议）；Anthropic/Gemini 有自己的消息格式，不处理。
+- 不改消息对象（原始 checkpoint 不动），净化只落在序列化后的 wire 载荷。
+- 同步/异步/流式/非流式四条路径都经 `_get_request_payload`，一处覆盖。
+- 不删孤儿 `ToolMessage`：id 存在不代表调用与响应顺序合法，按根因另行处理。
 
 ## 替代方案
 
-- 只清空 `invalid_tool_calls`：`additional_kwargs` 回退会让畸形调用重发；已被 wire payload 回归测试证伪，拒绝。
-- 只处理 `additional_kwargs`、不处理 `invalid_tool_calls`：模型侧仍收到 `invalid_tool_call` 变体；拒绝。
-- 在 `_convert_message_to_dict` 处打补丁：属于第三方内部实现，升级即失效；拒绝。
+- 动态 `_InvalidToolCallFilterMixin` 包装四个入口：覆盖所有供应商、范围过大，且掩盖消息链路本身的问题；拒绝。
+- 在 `_convert_message_to_dict` 打补丁：第三方内部实现，升级即失效；拒绝。
+- 全历史 id 集合清洗工具响应：会把「响应在前、调用在后」等非法序列保留，或误删实际执行结果；拒绝。
 
 ## 后果
 
-模型输入侧的畸形调用与孤儿工具响应在发送边界被统一消解，不再随供应商序列化实现变化而回退。过滤会丢失原始调用细节，因此每次过滤都写 warning 日志，保留可观测性。合法调用与其工具响应不受影响。
+发送给 DeepSeek 等接口的载荷不再含参数截断的 `function` 调用，改为明确的文本失败反馈。`invalid_tool_calls` 属性仍在 checkpoint 里原样保留（可观测、可追溯），仅在 wire 边界降级。非 OpenAI 兼容供应商不受影响。
 
 ## 验证
 
-`backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py` 断言**最终 wire payload**（经 `_convert_message_to_dict`）：
+`backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py`（真实 adapter + mock HTTP，断言最终请求体）：
 
-- 纯无效调用：wire 上不出现该调用，`invalid_tool_calls` 为空；
-- 有效/无效混合：wire 只保留 `call-good` 及其原始参数；
-- 不得原地修改入参（原消息的 `invalid_tool_calls` 与 `additional_kwargs` 不变）；
-- 孤儿 `ToolMessage` 随无效调用一起被删除；
-- content 里的 `invalid_tool_call` block 转文本，wire 上无该变体；
-- 流式入口（`_stream` / `_astream`）同样在发送前净化。
+- 纯无效调用：`tool_calls` 移除，content 追加失败反馈；
+- 有效/无效混合：wire 只保留 `call-good`，追加失败反馈；
+- 无无效调用：wire 原样不变；
+- 四条路径（`invoke`/`ainvoke`/`stream`/`astream`）都净化。

--- a/docs/develop-guides/decisions/implemented/2026-09-10-model-input-invalid-tool-call-sanitize.md
+++ b/docs/develop-guides/decisions/implemented/2026-09-10-model-input-invalid-tool-call-sanitize.md
@@ -1,0 +1,46 @@
+# 模型输入净化：invalid_tool_call 必须落在 wire payload 上
+
+状态：implemented
+类型：bug-fix
+Owner：backend/package/yuxi/models/chat.py
+
+## 问题
+
+DeepSeek 等接口对两类消息报错并中断整轮：
+
+1. `unknown variant invalid_tool_call`：模型生成的工具调用参数被截断/格式错误时，LangChain 记录 `invalid_tool_calls`，序列化后以该变体发往模型。
+2. `role='tool' must be a response to a preceding message with 'tool_calls'`：孤儿 `ToolMessage`（`tool_call_id` 已无对应 `tool_calls`）。
+
+只清空 `invalid_tool_calls` 解析字段并不能解决第 1 类：`langchain_openai` 的 `_convert_message_to_dict` 在 `tool_calls` 与 `invalid_tool_calls` **都为空**时会回退使用 `additional_kwargs["tool_calls"]`（OpenAI 响应的原始 wire 表示），把同一条截断参数的调用原样重发；而配对 `ToolMessage` 已被过滤删除，形成「有 tool_calls、无工具响应」的非法请求。
+
+## 决策
+
+净化必须作用在最终发送载荷上，并保持解析表示与原始表示一致：
+
+- 清空 `invalid_tool_calls`；
+- 把 `additional_kwargs["tool_calls"]` 收敛为「id 在合法 `tool_calls` 内」的子集（无合法调用时即为空列表，阻断 `_convert_message_to_dict` 的回退路径）；
+- content 数组里的 `invalid_tool_call` block 转文本；
+- 删除 `tool_call_id` 不在任何合法 `tool_calls` 内的孤儿 `ToolMessage`。
+
+净化返回**新的消息对象**，不原地修改入参——这些对象来自共享的 graph state 与 checkpoint。`_InvalidToolCallFilterMixin` 在 `_generate/_agenerate/_stream/_astream` 四个入口发送前统一调用。
+
+## 替代方案
+
+- 只清空 `invalid_tool_calls`：`additional_kwargs` 回退会让畸形调用重发；已被 wire payload 回归测试证伪，拒绝。
+- 只处理 `additional_kwargs`、不处理 `invalid_tool_calls`：模型侧仍收到 `invalid_tool_call` 变体；拒绝。
+- 在 `_convert_message_to_dict` 处打补丁：属于第三方内部实现，升级即失效；拒绝。
+
+## 后果
+
+模型输入侧的畸形调用与孤儿工具响应在发送边界被统一消解，不再随供应商序列化实现变化而回退。过滤会丢失原始调用细节，因此每次过滤都写 warning 日志，保留可观测性。合法调用与其工具响应不受影响。
+
+## 验证
+
+`backend/test/unit/models/test_chat_invalid_tool_call_sanitize.py` 断言**最终 wire payload**（经 `_convert_message_to_dict`）：
+
+- 纯无效调用：wire 上不出现该调用，`invalid_tool_calls` 为空；
+- 有效/无效混合：wire 只保留 `call-good` 及其原始参数；
+- 不得原地修改入参（原消息的 `invalid_tool_calls` 与 `additional_kwargs` 不变）；
+- 孤儿 `ToolMessage` 随无效调用一起被删除；
+- content 里的 `invalid_tool_call` block 转文本，wire 上无该变体；
+- 流式入口（`_stream` / `_astream`）同样在发送前净化。


### PR DESCRIPTION
## 现象

用 DeepSeek 等模型时，偶尔报两类错误导致整轮失败：

1. `unknown variant invalid_tool_call` —— 模型生成无效工具调用（JSON 参数截断/格式错）时，LangChain 记录 `invalid_tool_call`，序列化后以该变体发往模型，DeepSeek 不认识。
2. `role='tool' must be a response to a preceding message with 'tool_calls'` —— 孤儿 `ToolMessage`（`tool_call_id` 已无对应 `tool_calls`）。

## 机理

现有的 `normalize_tool_call_chunks` 只处理了「流式续片空串归一化」这一半，**没有**「清空 `invalid_tool_calls` 属性」「把 content 里的 `invalid_tool_call` block 转文本」「删除孤儿 ToolMessage」这三步。

## 改进方法

在消息发送前做三层净化：

1. `invalid_tool_calls` 属性清空；
2. content 数组里的 `invalid_tool_call` block 转成文本 `[工具调用失败] name: error`；
3. 删除 `tool_call_id` 不在任何合法 `tool_calls` 里的孤儿 `ToolMessage`。

通过 `_InvalidToolCallFilterMixin` 混入各类 ChatModel，重写 `_generate/_agenerate/_stream/_astream` 四个入口，统一在发送前净化。

## 效果

DeepSeek 等接口不再因 `invalid_tool_call` 变体或孤儿 ToolMessage 报错；单次工具调用失败降级为文本提示，不再拖垮整轮。