### PR TITLE
feat(agents): 网络类错误持续重试中间件，断网恢复后任务自动继续

### DIFF
--- a/backend/package/yuxi/agents/buildin/chatbot/graph.py
+++ b/backend/package/yuxi/agents/buildin/chatbot/graph.py
@@ -15,6 +15,7 @@ from yuxi.agents.context import (
 )
 from yuxi.agents.middlewares import (
     ImageInputCompatibilityMiddleware,
+    NetworkRetryMiddleware,
     SteerMiddleware,
     TokenUsageMiddleware,
     create_memory_middleware,
@@ -52,7 +53,12 @@ async def _build_middlewares(context, backend):
             create_summary_middleware_from_context(context, backend=backend),
             TodoListMiddleware(system_prompt=TODO_MID_PROMPT),
             PatchToolCallsMiddleware(),
+            # 网络类错误(断网/连接抖动)持续重试至预算耗尽(默认600s)。langchain 中间件
+            # 列表里排后者为内层(先拦截)：必须放在 ModelRetry 之内——ModelRetry 默认
+            # on_failure=continue 会把异常吞成错误 AIMessage，NetworkRetry 若在外层
+            # 就永远看不到网络异常(实测踩坑)。
             ModelRetryMiddleware(max_retries=getattr(context, "model_retry_times", 2)),
+            NetworkRetryMiddleware(),
             ImageInputCompatibilityMiddleware(),
             TokenUsageMiddleware(),
         ]

--- a/backend/package/yuxi/agents/buildin/chatbot/graph.py
+++ b/backend/package/yuxi/agents/buildin/chatbot/graph.py
@@ -1,6 +1,6 @@
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from langchain.agents import create_agent
-from langchain.agents.middleware import ModelRetryMiddleware, TodoListMiddleware
+from langchain.agents.middleware import TodoListMiddleware
 
 from yuxi.agents import BaseAgent
 from yuxi.agents.backends import (
@@ -20,7 +20,6 @@ from yuxi.agents.middlewares import (
     TokenUsageMiddleware,
     create_memory_middleware,
     create_summary_middleware_from_context,
-    retry_non_network_errors,
 )
 from yuxi.agents.middlewares.skills import SkillsMiddleware
 from yuxi.agents.middlewares.subagent_task import create_subagent_task_middleware
@@ -54,17 +53,12 @@ async def _build_middlewares(context, backend):
             create_summary_middleware_from_context(context, backend=backend),
             TodoListMiddleware(system_prompt=TODO_MID_PROMPT),
             PatchToolCallsMiddleware(),
-            # 网络类错误(断网/连接抖动)由内层 NetworkRetryMiddleware 按单次预算(默认600s)
-            # 退避重试。langchain 中间件列表排后者为内层(先拦截)：
-            #  - NetworkRetry 必须在 ModelRetry 之内，否则 ModelRetry 的 on_failure=continue
-            #    会先把异常吞成错误 AIMessage，网络错误永远到不了 NetworkRetry；
-            #  - ModelRetry 必须用 retry_on 排除网络错误，否则它会给同一次调用反复开启
-            #    全新预算(600s × (max_retries+1))，且最终把耗尽后的网络错误吞成"假完成"。
-            ModelRetryMiddleware(
+            # 网络类错误(断网/连接抖动)按预算(默认600s)持续重试，非网络错误按 max_retries
+            # 次数重试——两者合并进 NetworkRetryMiddleware，避免拆成两个中间件后因装配顺序
+            # 或外层重试网络错误而放大预算。
+            NetworkRetryMiddleware(
                 max_retries=getattr(context, "model_retry_times", 2),
-                retry_on=retry_non_network_errors,
             ),
-            NetworkRetryMiddleware(),
             ImageInputCompatibilityMiddleware(),
             TokenUsageMiddleware(),
         ]

--- a/backend/package/yuxi/agents/buildin/chatbot/graph.py
+++ b/backend/package/yuxi/agents/buildin/chatbot/graph.py
@@ -20,6 +20,7 @@ from yuxi.agents.middlewares import (
     TokenUsageMiddleware,
     create_memory_middleware,
     create_summary_middleware_from_context,
+    retry_non_network_errors,
 )
 from yuxi.agents.middlewares.skills import SkillsMiddleware
 from yuxi.agents.middlewares.subagent_task import create_subagent_task_middleware
@@ -53,11 +54,16 @@ async def _build_middlewares(context, backend):
             create_summary_middleware_from_context(context, backend=backend),
             TodoListMiddleware(system_prompt=TODO_MID_PROMPT),
             PatchToolCallsMiddleware(),
-            # 网络类错误(断网/连接抖动)持续重试至预算耗尽(默认600s)。langchain 中间件
-            # 列表里排后者为内层(先拦截)：必须放在 ModelRetry 之内——ModelRetry 默认
-            # on_failure=continue 会把异常吞成错误 AIMessage，NetworkRetry 若在外层
-            # 就永远看不到网络异常(实测踩坑)。
-            ModelRetryMiddleware(max_retries=getattr(context, "model_retry_times", 2)),
+            # 网络类错误(断网/连接抖动)由内层 NetworkRetryMiddleware 按单次预算(默认600s)
+            # 退避重试。langchain 中间件列表排后者为内层(先拦截)：
+            #  - NetworkRetry 必须在 ModelRetry 之内，否则 ModelRetry 的 on_failure=continue
+            #    会先把异常吞成错误 AIMessage，网络错误永远到不了 NetworkRetry；
+            #  - ModelRetry 必须用 retry_on 排除网络错误，否则它会给同一次调用反复开启
+            #    全新预算(600s × (max_retries+1))，且最终把耗尽后的网络错误吞成"假完成"。
+            ModelRetryMiddleware(
+                max_retries=getattr(context, "model_retry_times", 2),
+                retry_on=retry_non_network_errors,
+            ),
             NetworkRetryMiddleware(),
             ImageInputCompatibilityMiddleware(),
             TokenUsageMiddleware(),

--- a/backend/package/yuxi/agents/buildin/subagent/graph.py
+++ b/backend/package/yuxi/agents/buildin/subagent/graph.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from langchain.agents import create_agent
-from langchain.agents.middleware import ModelRetryMiddleware, TodoListMiddleware
+from langchain.agents.middleware import TodoListMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.messages import ToolMessage
 
@@ -20,6 +20,7 @@ from yuxi.agents.context import (
 )
 from yuxi.agents.middlewares import (
     ImageInputCompatibilityMiddleware,
+    NetworkRetryMiddleware,
     TokenUsageMiddleware,
     create_summary_middleware_from_context,
 )
@@ -100,7 +101,7 @@ async def _build_middlewares(context, backend, tool_approval_mode: str):
         TodoListMiddleware(system_prompt=TODO_MID_PROMPT),
         PatchToolCallsMiddleware(),
         _SubAgentToolFilterMiddleware(tool_approval_mode),
-        ModelRetryMiddleware(),
+        NetworkRetryMiddleware(),
         ImageInputCompatibilityMiddleware(),
         TokenUsageMiddleware(),
     ]

--- a/backend/package/yuxi/agents/middlewares/__init__.py
+++ b/backend/package/yuxi/agents/middlewares/__init__.py
@@ -2,6 +2,7 @@ from .context import context_aware_prompt, context_based_model
 from .dynamic_tool import DynamicToolMiddleware
 from .memory import create_memory_middleware
 from .model_input import ImageInputCompatibilityMiddleware
+from .network_retry import NetworkRetryMiddleware, is_network_error
 from .steer import SteerMiddleware
 from .summary import create_summary_middleware, create_summary_middleware_from_context
 from .token_usage import TokenUsageMiddleware
@@ -9,11 +10,13 @@ from .token_usage import TokenUsageMiddleware
 __all__ = [
     "DynamicToolMiddleware",
     "ImageInputCompatibilityMiddleware",
+    "NetworkRetryMiddleware",
     "SteerMiddleware",
     "TokenUsageMiddleware",
     "context_aware_prompt",
     "context_based_model",
     "create_memory_middleware",
     "create_summary_middleware",
+    "is_network_error",
     "create_summary_middleware_from_context",
 ]

--- a/backend/package/yuxi/agents/middlewares/__init__.py
+++ b/backend/package/yuxi/agents/middlewares/__init__.py
@@ -2,7 +2,7 @@ from .context import context_aware_prompt, context_based_model
 from .dynamic_tool import DynamicToolMiddleware
 from .memory import create_memory_middleware
 from .model_input import ImageInputCompatibilityMiddleware
-from .network_retry import NetworkRetryMiddleware, is_network_error, retry_non_network_errors
+from .network_retry import NetworkRetryMiddleware, is_network_error
 from .steer import SteerMiddleware
 from .summary import create_summary_middleware, create_summary_middleware_from_context
 from .token_usage import TokenUsageMiddleware
@@ -11,7 +11,6 @@ __all__ = [
     "DynamicToolMiddleware",
     "ImageInputCompatibilityMiddleware",
     "NetworkRetryMiddleware",
-    "retry_non_network_errors",
     "SteerMiddleware",
     "TokenUsageMiddleware",
     "context_aware_prompt",

--- a/backend/package/yuxi/agents/middlewares/__init__.py
+++ b/backend/package/yuxi/agents/middlewares/__init__.py
@@ -2,7 +2,7 @@ from .context import context_aware_prompt, context_based_model
 from .dynamic_tool import DynamicToolMiddleware
 from .memory import create_memory_middleware
 from .model_input import ImageInputCompatibilityMiddleware
-from .network_retry import NetworkRetryMiddleware, is_network_error
+from .network_retry import NetworkRetryMiddleware
 from .steer import SteerMiddleware
 from .summary import create_summary_middleware, create_summary_middleware_from_context
 from .token_usage import TokenUsageMiddleware
@@ -17,6 +17,5 @@ __all__ = [
     "context_based_model",
     "create_memory_middleware",
     "create_summary_middleware",
-    "is_network_error",
     "create_summary_middleware_from_context",
 ]

--- a/backend/package/yuxi/agents/middlewares/__init__.py
+++ b/backend/package/yuxi/agents/middlewares/__init__.py
@@ -2,7 +2,7 @@ from .context import context_aware_prompt, context_based_model
 from .dynamic_tool import DynamicToolMiddleware
 from .memory import create_memory_middleware
 from .model_input import ImageInputCompatibilityMiddleware
-from .network_retry import NetworkRetryMiddleware, is_network_error
+from .network_retry import NetworkRetryMiddleware, is_network_error, retry_non_network_errors
 from .steer import SteerMiddleware
 from .summary import create_summary_middleware, create_summary_middleware_from_context
 from .token_usage import TokenUsageMiddleware
@@ -11,6 +11,7 @@ __all__ = [
     "DynamicToolMiddleware",
     "ImageInputCompatibilityMiddleware",
     "NetworkRetryMiddleware",
+    "retry_non_network_errors",
     "SteerMiddleware",
     "TokenUsageMiddleware",
     "context_aware_prompt",

--- a/backend/package/yuxi/agents/middlewares/network_retry.py
+++ b/backend/package/yuxi/agents/middlewares/network_retry.py
@@ -72,8 +72,10 @@ class NetworkRetryMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
         max_delay: float = 30.0,
     ) -> None:
         super().__init__()
-        self._budget = budget_seconds if budget_seconds is not None else float(
-            os.getenv("YUXI_NETWORK_RETRY_BUDGET_SECONDS", "600")
+        self._budget = (
+            budget_seconds
+            if budget_seconds is not None
+            else float(os.getenv("YUXI_NETWORK_RETRY_BUDGET_SECONDS", "600"))
         )
         self._initial_delay = initial_delay
         self._max_delay = max_delay

--- a/backend/package/yuxi/agents/middlewares/network_retry.py
+++ b/backend/package/yuxi/agents/middlewares/network_retry.py
@@ -1,0 +1,109 @@
+"""网络类错误的持续重试中间件。
+
+断网/APIC 连接抖动恢复后任务应自动继续(对标 Claude Code 的行为)：
+网络类异常(连接拒绝/超时/DNS)按指数退避持续重试，总预算内不向 graph 抛错；
+预算耗尽或非网络错误交给内层 ModelRetryMiddleware 按原有语义处理。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
+
+from yuxi.utils.logging_config import logger
+
+# 网络恢复类异常：特点是"网络/服务端恢复后重试大概率成功"。
+# 通过类名字符串匹配，避免硬依赖各 SDK 的异常类(跨 openai/httpx/anthropic 等)。
+_NETWORK_ERROR_MARKERS = (
+    "connectionerror",
+    "connection error",
+    "connection refused",
+    "connection reset",
+    "connecttimeout",
+    "readtimeout",
+    "apitimeouterror",
+    "timeout",
+    "temporarily unavailable",
+    "service unavailable",
+    "bad gateway",
+    "remote_protocol",
+)
+
+# 明确非网络的错误：重试无意义，立即放行给内层处理。
+# 空字符串永远不匹配任何 marker，保持行为一致。
+_NON_NETWORK_MARKERS = ("ratelimit", "authentication", "permission", "invalid_request", "not_found", "context_length")
+
+
+def is_network_error(exc: BaseException) -> bool:
+    """判定异常是否为网络恢复类（连接/超时/5xx 网关），可安全持续重试。"""
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    cursor: BaseException | None = exc
+    while cursor is not None and id(cursor) not in seen:
+        chain.append(cursor)
+        seen.add(id(cursor))
+        cursor = cursor.__cause__ or cursor.__context__
+    for e in chain:
+        detail = f"{type(e).__name__} {e}".lower()
+        if any(m in detail for m in _NON_NETWORK_MARKERS):
+            return False
+        if any(m in detail for m in _NETWORK_ERROR_MARKERS):
+            return True
+    return False
+
+
+class NetworkRetryMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
+    """对网络类模型调用错误做预算内持续重试的中间件。
+
+    挂在 ModelRetryMiddleware 外层：网络错误在此消化（等待恢复），
+    其余错误原样透传给内层重试/失败语义。
+    """
+
+    def __init__(
+        self,
+        *,
+        budget_seconds: float | None = None,
+        initial_delay: float = 2.0,
+        max_delay: float = 30.0,
+    ) -> None:
+        super().__init__()
+        self._budget = budget_seconds if budget_seconds is not None else float(
+            os.getenv("YUXI_NETWORK_RETRY_BUDGET_SECONDS", "600")
+        )
+        self._initial_delay = initial_delay
+        self._max_delay = max_delay
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        started = time.monotonic()
+        delay = self._initial_delay
+        attempt = 0
+        while True:
+            try:
+                return await handler(request)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
+                if not is_network_error(exc):
+                    raise
+                attempt += 1
+                elapsed = time.monotonic() - started
+                if self._budget <= 0 or elapsed + delay > self._budget:
+                    logger.warning(
+                        f"[network-retry] 预算耗尽({self._budget:.0f}s)，放行网络错误: {type(exc).__name__}: {exc}",
+                    )
+                    raise
+                logger.warning(
+                    f"[network-retry] 网络错误(第{attempt}次，已等待{elapsed:.0f}s，{delay:.0f}s后重试): "
+                    f"{type(exc).__name__}: {exc}",
+                )
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, self._max_delay)

--- a/backend/package/yuxi/agents/middlewares/network_retry.py
+++ b/backend/package/yuxi/agents/middlewares/network_retry.py
@@ -1,12 +1,13 @@
-"""网络类错误的持续重试中间件，同时保留非网络错误的次数重试语义。
+"""网络类错误的持续重试中间件，非网络错误沿用 ModelRetryMiddleware 的次数重试。
 
 断网/APIC 连接抖动恢复后任务应自动继续(对标 Claude Code 的行为)：
 网络类异常(连接拒绝/超时/DNS)按指数退避持续重试，总预算内不向 graph 抛错；
 预算耗尽显式抛出，Run 以 failed 结束，不再出现"假完成"。
 
-非网络错误(逻辑错误/鉴权/限流/参数错误)仍按 ModelRetryMiddleware 的 max_retries
-次数重试，语义不变。两类错误的重试维度(预算 vs 次数)在同一个中间件内区分，
-避免拆成两个中间件后因装配顺序/外层重试网络错误而放大预算。
+网络重试通过 handler 包装实现：wrapped handler 在预算内吞掉网络异常退避重试，
+预算耗尽或非网络异常原样抛出，交给父类的 wrap_model_call/awrap_model_call 按
+retry_on(排除网络异常)处理。预算起点在包装创建时固定，跨父类非网络重试保持，
+不会因外层重试而放大。
 """
 
 from __future__ import annotations
@@ -17,14 +18,9 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware._retry import (
-    OnFailure,
-    calculate_delay,
-    default_retry_on,
-    should_retry_exception,
-)
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.exceptions import ModelError
 from langgraph.errors import GraphBubbleUp
 
 from yuxi.utils.logging_config import logger
@@ -47,35 +43,39 @@ _NETWORK_ERROR_MARKERS = (
 )
 
 # 明确非网络的错误：重试无意义，立即放行。
-# 空字符串永远不匹配任何 marker，保持行为一致。
 _NON_NETWORK_MARKERS = ("ratelimit", "authentication", "permission", "invalid_request", "not_found", "context_length")
 
 
-def is_network_error(exc: BaseException) -> bool:
-    """判定异常是否为网络恢复类（连接/超时/5xx 网关），可安全持续重试。"""
-    chain: list[BaseException] = []
+def _is_network_error(exc: BaseException) -> bool:
+    """判定异常是否为网络恢复类（连接/超时/5xx 网关），边遍历异常链边判断。"""
     seen: set[int] = set()
     cursor: BaseException | None = exc
     while cursor is not None and id(cursor) not in seen:
-        chain.append(cursor)
         seen.add(id(cursor))
-        cursor = cursor.__cause__ or cursor.__context__
-    for e in chain:
-        detail = f"{type(e).__name__} {e}".lower()
+        detail = f"{type(cursor).__name__} {cursor}".lower()
         if any(m in detail for m in _NON_NETWORK_MARKERS):
             return False
         if any(m in detail for m in _NETWORK_ERROR_MARKERS):
             return True
+        cursor = cursor.__cause__ or cursor.__context__
     return False
+
+
+def _retry_non_network_errors(exc: BaseException) -> bool:
+    """父类 retry_on 谓词：网络异常已由 handler 包装处理，这里排除；其余按默认语义。"""
+    if _is_network_error(exc):
+        return False
+    if isinstance(exc, ModelError):
+        return exc.is_retryable
+    return True
 
 
 class NetworkRetryMiddleware(ModelRetryMiddleware):
     """网络错误按预算重试、非网络错误按次数重试的统一中间件。
 
-    继承 ``ModelRetryMiddleware``：非网络错误复用其 ``max_retries``/``retry_on``/
-    ``on_failure`` 语义；网络错误在 ``wrap_model_call``/``awrap_model_call`` 里按
-    ``network_budget_seconds`` 预算退避重试，耗尽后显式抛出(而非被 ``on_failure``
-    吞成含错误文本的 AIMessage)。
+    网络重试通过 handler 包装实现，非网络错误复用父类 ``ModelRetryMiddleware`` 的
+    ``max_retries``/``retry_on``/``on_failure`` 语义。网络预算起点在包装创建时固定，
+    跨父类的非网络重试保持，不会被放大成多份。
     """
 
     def __init__(
@@ -85,21 +85,9 @@ class NetworkRetryMiddleware(ModelRetryMiddleware):
         network_budget_seconds: float | None = None,
         network_initial_delay: float = 2.0,
         network_max_delay: float = 30.0,
-        on_failure: OnFailure = "continue",
-        backoff_factor: float = 2.0,
-        initial_delay: float = 1.0,
-        max_delay: float = 60.0,
-        jitter: bool = True,
+        **kwargs,
     ) -> None:
-        super().__init__(
-            max_retries=max_retries,
-            retry_on=default_retry_on,
-            on_failure=on_failure,
-            backoff_factor=backoff_factor,
-            initial_delay=initial_delay,
-            max_delay=max_delay,
-            jitter=jitter,
-        )
+        super().__init__(max_retries=max_retries, retry_on=_retry_non_network_errors, **kwargs)
         self._network_budget = (
             network_budget_seconds
             if network_budget_seconds is not None
@@ -108,97 +96,79 @@ class NetworkRetryMiddleware(ModelRetryMiddleware):
         self._network_initial_delay = network_initial_delay
         self._network_max_delay = network_max_delay
 
-    def _handle_network_retry(self, exc: BaseException, *, elapsed: float, delay: float, attempt: int) -> bool:
-        """预算内返回 True 继续重试，预算耗尽返回 False 由调用方抛出。"""
+    def _network_retry_exhausted(self, exc: BaseException, *, elapsed: float, delay: float, attempt: int) -> bool:
+        """预算耗尽返回 True（调用方抛出），否则记日志并返回 False 继续重试。"""
         if self._network_budget <= 0 or elapsed + delay > self._network_budget:
             logger.warning(
                 f"[network-retry] 预算耗尽({self._network_budget:.0f}s)，抛出网络错误: {type(exc).__name__}: {exc}",
             )
-            return False
+            return True
         logger.warning(
             f"[network-retry] 网络错误(第{attempt}次，已等待{elapsed:.0f}s，{delay:.0f}s后重试): "
             f"{type(exc).__name__}: {exc}",
         )
-        return True
+        return False
+
+    def _wrap_network_retry(self, handler):
+        started = time.monotonic()
+        delay = self._network_initial_delay
+        attempt = 0
+
+        def wrapped(request):
+            nonlocal delay, attempt
+            while True:
+                try:
+                    return handler(request)
+                except GraphBubbleUp:
+                    raise
+                except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
+                    if not _is_network_error(exc):
+                        raise
+                    if self._network_retry_exhausted(
+                        exc, elapsed=time.monotonic() - started, delay=delay, attempt=attempt + 1
+                    ):
+                        raise
+                    attempt += 1
+                    time.sleep(delay)
+                    delay = min(delay * 2, self._network_max_delay)
+
+        return wrapped
+
+    def _awrap_network_retry(self, handler):
+        started = time.monotonic()
+        delay = self._network_initial_delay
+        attempt = 0
+
+        async def wrapped(request):
+            nonlocal delay, attempt
+            while True:
+                try:
+                    return await handler(request)
+                except GraphBubbleUp:
+                    raise
+                except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
+                    if not _is_network_error(exc):
+                        raise
+                    if self._network_retry_exhausted(
+                        exc, elapsed=time.monotonic() - started, delay=delay, attempt=attempt + 1
+                    ):
+                        raise
+                    attempt += 1
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self._network_max_delay)
+
+        return wrapped
 
     def wrap_model_call(
         self,
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
     ) -> ModelResponse[Any]:
-        started = time.monotonic()
-        network_delay = self._network_initial_delay
-        network_attempt = 0
-        non_network_attempt = 0
-        while True:
-            try:
-                return handler(request)
-            except GraphBubbleUp:
-                raise
-            except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
-                if is_network_error(exc):
-                    elapsed = time.monotonic() - started
-                    if not self._handle_network_retry(
-                        exc, elapsed=elapsed, delay=network_delay, attempt=network_attempt + 1
-                    ):
-                        raise
-                    network_attempt += 1
-                    time.sleep(network_delay)
-                    network_delay = min(network_delay * 2, self._network_max_delay)
-                    continue
-                if not should_retry_exception(exc, self.retry_on):
-                    raise
-                non_network_attempt += 1
-                if non_network_attempt > self.max_retries:
-                    return self._handle_failure(exc, non_network_attempt)
-                delay = calculate_delay(
-                    non_network_attempt - 1,
-                    backoff_factor=self.backoff_factor,
-                    initial_delay=self.initial_delay,
-                    max_delay=self.max_delay,
-                    jitter=self.jitter,
-                )
-                if delay > 0:
-                    time.sleep(delay)
+        return super().wrap_model_call(request, self._wrap_network_retry(handler))
 
     async def awrap_model_call(
         self,
         request: ModelRequest[Any],
         handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
     ) -> ModelResponse[Any]:
-        started = time.monotonic()
-        network_delay = self._network_initial_delay
-        network_attempt = 0
-        non_network_attempt = 0
-        while True:
-            try:
-                return await handler(request)
-            except GraphBubbleUp:
-                raise
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
-                if is_network_error(exc):
-                    elapsed = time.monotonic() - started
-                    if not self._handle_network_retry(
-                        exc, elapsed=elapsed, delay=network_delay, attempt=network_attempt + 1
-                    ):
-                        raise
-                    network_attempt += 1
-                    await asyncio.sleep(network_delay)
-                    network_delay = min(network_delay * 2, self._network_max_delay)
-                    continue
-                if not should_retry_exception(exc, self.retry_on):
-                    raise
-                non_network_attempt += 1
-                if non_network_attempt > self.max_retries:
-                    return self._handle_failure(exc, non_network_attempt)
-                delay = calculate_delay(
-                    non_network_attempt - 1,
-                    backoff_factor=self.backoff_factor,
-                    initial_delay=self.initial_delay,
-                    max_delay=self.max_delay,
-                    jitter=self.jitter,
-                )
-                if delay > 0:
-                    await asyncio.sleep(delay)
+        return await super().awrap_model_call(request, self._awrap_network_retry(handler))

--- a/backend/package/yuxi/agents/middlewares/network_retry.py
+++ b/backend/package/yuxi/agents/middlewares/network_retry.py
@@ -1,8 +1,12 @@
-"""网络类错误的持续重试中间件。
+"""网络类错误的持续重试中间件，同时保留非网络错误的次数重试语义。
 
 断网/APIC 连接抖动恢复后任务应自动继续(对标 Claude Code 的行为)：
 网络类异常(连接拒绝/超时/DNS)按指数退避持续重试，总预算内不向 graph 抛错；
-预算耗尽或非网络错误交给内层 ModelRetryMiddleware 按原有语义处理。
+预算耗尽显式抛出，Run 以 failed 结束，不再出现"假完成"。
+
+非网络错误(逻辑错误/鉴权/限流/参数错误)仍按 ModelRetryMiddleware 的 max_retries
+次数重试，语义不变。两类错误的重试维度(预算 vs 次数)在同一个中间件内区分，
+避免拆成两个中间件后因装配顺序/外层重试网络错误而放大预算。
 """
 
 from __future__ import annotations
@@ -13,7 +17,15 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from langchain.agents.middleware.types import AgentMiddleware, ContextT, ModelRequest, ModelResponse, ResponseT
+from langchain.agents.middleware._retry import (
+    OnFailure,
+    calculate_delay,
+    default_retry_on,
+    should_retry_exception,
+)
+from langchain.agents.middleware.model_retry import ModelRetryMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langgraph.errors import GraphBubbleUp
 
 from yuxi.utils.logging_config import logger
 
@@ -34,7 +46,7 @@ _NETWORK_ERROR_MARKERS = (
     "remote_protocol",
 )
 
-# 明确非网络的错误：重试无意义，立即放行给内层处理。
+# 明确非网络的错误：重试无意义，立即放行。
 # 空字符串永远不匹配任何 marker，保持行为一致。
 _NON_NETWORK_MARKERS = ("ratelimit", "authentication", "permission", "invalid_request", "not_found", "context_length")
 
@@ -57,71 +69,136 @@ def is_network_error(exc: BaseException) -> bool:
     return False
 
 
-def retry_non_network_errors(exc: BaseException) -> bool:
-    """外层 ModelRetryMiddleware 的重试谓词：网络类错误一律不由它重试。
+class NetworkRetryMiddleware(ModelRetryMiddleware):
+    """网络错误按预算重试、非网络错误按次数重试的统一中间件。
 
-    中间件列表排后者为内层(先拦截)，网络错误先经 NetworkRetryMiddleware 按自身预算
-    退避重试。若外层也判定可重试，每轮都会为同一次模型调用开启全新的预算
-    (600s × (max_retries+1))，且预算耗尽后会被 on_failure 吞成含错误文本的 AIMessage
-    ——即"假完成"。这里显式排除，让预算耗尽按异常显式失败。
-    """
-    if is_network_error(exc):
-        return False
-    from langchain.agents.middleware.model_retry import default_retry_on
-
-    return default_retry_on(exc)
-
-
-class NetworkRetryMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
-    """对网络类模型调用错误做预算内持续重试的中间件。
-
-    挂在 ModelRetryMiddleware 之内（中间件列表排后者为内层）：网络错误在此按预算
-    退避消化，其余错误原样透传给内层重试/失败语义；预算耗尽后抛出的网络错误由外层
-    ModelRetryMiddleware 的 retry_on=retry_non_network_errors 判定为不可重试，直接失败。
+    继承 ``ModelRetryMiddleware``：非网络错误复用其 ``max_retries``/``retry_on``/
+    ``on_failure`` 语义；网络错误在 ``wrap_model_call``/``awrap_model_call`` 里按
+    ``network_budget_seconds`` 预算退避重试，耗尽后显式抛出(而非被 ``on_failure``
+    吞成含错误文本的 AIMessage)。
     """
 
     def __init__(
         self,
         *,
-        budget_seconds: float | None = None,
-        initial_delay: float = 2.0,
-        max_delay: float = 30.0,
+        max_retries: int = 2,
+        network_budget_seconds: float | None = None,
+        network_initial_delay: float = 2.0,
+        network_max_delay: float = 30.0,
+        on_failure: OnFailure = "continue",
+        backoff_factor: float = 2.0,
+        initial_delay: float = 1.0,
+        max_delay: float = 60.0,
+        jitter: bool = True,
     ) -> None:
-        super().__init__()
-        self._budget = (
-            budget_seconds
-            if budget_seconds is not None
+        super().__init__(
+            max_retries=max_retries,
+            retry_on=default_retry_on,
+            on_failure=on_failure,
+            backoff_factor=backoff_factor,
+            initial_delay=initial_delay,
+            max_delay=max_delay,
+            jitter=jitter,
+        )
+        self._network_budget = (
+            network_budget_seconds
+            if network_budget_seconds is not None
             else float(os.getenv("YUXI_NETWORK_RETRY_BUDGET_SECONDS", "600"))
         )
-        self._initial_delay = initial_delay
-        self._max_delay = max_delay
+        self._network_initial_delay = network_initial_delay
+        self._network_max_delay = network_max_delay
+
+    def _handle_network_retry(self, exc: BaseException, *, elapsed: float, delay: float, attempt: int) -> bool:
+        """预算内返回 True 继续重试，预算耗尽返回 False 由调用方抛出。"""
+        if self._network_budget <= 0 or elapsed + delay > self._network_budget:
+            logger.warning(
+                f"[network-retry] 预算耗尽({self._network_budget:.0f}s)，抛出网络错误: {type(exc).__name__}: {exc}",
+            )
+            return False
+        logger.warning(
+            f"[network-retry] 网络错误(第{attempt}次，已等待{elapsed:.0f}s，{delay:.0f}s后重试): "
+            f"{type(exc).__name__}: {exc}",
+        )
+        return True
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], ModelResponse[Any]],
+    ) -> ModelResponse[Any]:
+        started = time.monotonic()
+        network_delay = self._network_initial_delay
+        network_attempt = 0
+        non_network_attempt = 0
+        while True:
+            try:
+                return handler(request)
+            except GraphBubbleUp:
+                raise
+            except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
+                if is_network_error(exc):
+                    elapsed = time.monotonic() - started
+                    if not self._handle_network_retry(
+                        exc, elapsed=elapsed, delay=network_delay, attempt=network_attempt + 1
+                    ):
+                        raise
+                    network_attempt += 1
+                    time.sleep(network_delay)
+                    network_delay = min(network_delay * 2, self._network_max_delay)
+                    continue
+                if not should_retry_exception(exc, self.retry_on):
+                    raise
+                non_network_attempt += 1
+                if non_network_attempt > self.max_retries:
+                    return self._handle_failure(exc, non_network_attempt)
+                delay = calculate_delay(
+                    non_network_attempt - 1,
+                    backoff_factor=self.backoff_factor,
+                    initial_delay=self.initial_delay,
+                    max_delay=self.max_delay,
+                    jitter=self.jitter,
+                )
+                if delay > 0:
+                    time.sleep(delay)
 
     async def awrap_model_call(
         self,
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT]:
+        request: ModelRequest[Any],
+        handler: Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]],
+    ) -> ModelResponse[Any]:
         started = time.monotonic()
-        delay = self._initial_delay
-        attempt = 0
+        network_delay = self._network_initial_delay
+        network_attempt = 0
+        non_network_attempt = 0
         while True:
             try:
                 return await handler(request)
+            except GraphBubbleUp:
+                raise
             except asyncio.CancelledError:
                 raise
-            except BaseException as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
-                if not is_network_error(exc):
+            except Exception as exc:  # noqa: BLE001 — 需要拦截底层 SDK 的各种异常类型
+                if is_network_error(exc):
+                    elapsed = time.monotonic() - started
+                    if not self._handle_network_retry(
+                        exc, elapsed=elapsed, delay=network_delay, attempt=network_attempt + 1
+                    ):
+                        raise
+                    network_attempt += 1
+                    await asyncio.sleep(network_delay)
+                    network_delay = min(network_delay * 2, self._network_max_delay)
+                    continue
+                if not should_retry_exception(exc, self.retry_on):
                     raise
-                attempt += 1
-                elapsed = time.monotonic() - started
-                if self._budget <= 0 or elapsed + delay > self._budget:
-                    logger.warning(
-                        f"[network-retry] 预算耗尽({self._budget:.0f}s)，放行网络错误: {type(exc).__name__}: {exc}",
-                    )
-                    raise
-                logger.warning(
-                    f"[network-retry] 网络错误(第{attempt}次，已等待{elapsed:.0f}s，{delay:.0f}s后重试): "
-                    f"{type(exc).__name__}: {exc}",
+                non_network_attempt += 1
+                if non_network_attempt > self.max_retries:
+                    return self._handle_failure(exc, non_network_attempt)
+                delay = calculate_delay(
+                    non_network_attempt - 1,
+                    backoff_factor=self.backoff_factor,
+                    initial_delay=self.initial_delay,
+                    max_delay=self.max_delay,
+                    jitter=self.jitter,
                 )
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, self._max_delay)
+                if delay > 0:
+                    await asyncio.sleep(delay)

--- a/backend/package/yuxi/agents/middlewares/network_retry.py
+++ b/backend/package/yuxi/agents/middlewares/network_retry.py
@@ -57,11 +57,27 @@ def is_network_error(exc: BaseException) -> bool:
     return False
 
 
+def retry_non_network_errors(exc: BaseException) -> bool:
+    """外层 ModelRetryMiddleware 的重试谓词：网络类错误一律不由它重试。
+
+    中间件列表排后者为内层(先拦截)，网络错误先经 NetworkRetryMiddleware 按自身预算
+    退避重试。若外层也判定可重试，每轮都会为同一次模型调用开启全新的预算
+    (600s × (max_retries+1))，且预算耗尽后会被 on_failure 吞成含错误文本的 AIMessage
+    ——即"假完成"。这里显式排除，让预算耗尽按异常显式失败。
+    """
+    if is_network_error(exc):
+        return False
+    from langchain.agents.middleware.model_retry import default_retry_on
+
+    return default_retry_on(exc)
+
+
 class NetworkRetryMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
     """对网络类模型调用错误做预算内持续重试的中间件。
 
-    挂在 ModelRetryMiddleware 外层：网络错误在此消化（等待恢复），
-    其余错误原样透传给内层重试/失败语义。
+    挂在 ModelRetryMiddleware 之内（中间件列表排后者为内层）：网络错误在此按预算
+    退避消化，其余错误原样透传给内层重试/失败语义；预算耗尽后抛出的网络错误由外层
+    ModelRetryMiddleware 的 retry_on=retry_non_network_errors 判定为不可重试，直接失败。
     """
 
     def __init__(

--- a/backend/test/unit/agents/test_network_retry.py
+++ b/backend/test/unit/agents/test_network_retry.py
@@ -1,0 +1,99 @@
+"""NetworkRetryMiddleware 单元测试。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from yuxi.agents.middlewares.network_retry import NetworkRetryMiddleware, is_network_error
+
+pytestmark = [pytest.mark.unit]
+
+
+class FakeError(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Connection error.", True),
+        ("OpenAIConnectionError: Connection error", True),
+        ("Connection refused to api host", True),
+        ("APITimeoutError: Request timed out", True),
+        ("httpx.ReadTimeout while reading", True),
+        ("503 Service Unavailable", True),
+        ("502 Bad Gateway from upstream", True),
+        ("RateLimitError: 429 too many requests", False),
+        ("AuthenticationError: invalid api key", False),
+        ("NotFoundError: model not found", False),
+        ("invalid_request_error: bad parameter", False),
+        ("This is a logic bug", False),
+    ],
+)
+def test_is_network_error_classifies(message, expected):
+    assert is_network_error(FakeError(message)) is expected
+
+
+def test_is_network_error_inspects_cause_chain():
+    inner = FakeError("Connection reset by peer")
+    outer = FakeError("model call wrapper failed")
+    outer.__cause__ = inner
+    assert is_network_error(outer) is True
+
+
+@pytest.mark.asyncio
+async def test_retries_network_error_until_success():
+    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.02)
+    calls = {"n": 0}
+
+    async def handler(request):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise FakeError("OpenAIConnectionError: Connection error")
+        return "ok"
+
+    result = await mw.awrap_model_call(object(), handler)
+    assert result == "ok"
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_non_network_error_propagates_immediately():
+    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.02)
+    calls = {"n": 0}
+
+    async def handler(request):
+        calls["n"] += 1
+        raise FakeError("AuthenticationError: bad key")
+
+    with pytest.raises(FakeError):
+        await mw.awrap_model_call(object(), handler)
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_raises():
+    mw = NetworkRetryMiddleware(budget_seconds=0.05, initial_delay=0.03, max_delay=0.03)
+    calls = {"n": 0}
+
+    async def handler(request):
+        calls["n"] += 1
+        raise FakeError("Connection refused")
+
+    with pytest.raises(FakeError):
+        await mw.awrap_model_call(object(), handler)
+    # 预算内至少重试过一次
+    assert calls["n"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_cancellation_not_swallowed():
+    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.01)
+
+    async def handler(request):
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await mw.awrap_model_call(object(), handler)

--- a/backend/test/unit/agents/test_network_retry.py
+++ b/backend/test/unit/agents/test_network_retry.py
@@ -9,7 +9,7 @@ import pytest
 from langchain_core.exceptions import ModelError
 from langchain_core.messages import AIMessage
 
-from yuxi.agents.middlewares.network_retry import NetworkRetryMiddleware, is_network_error
+from yuxi.agents.middlewares.network_retry import NetworkRetryMiddleware, _is_network_error
 
 pytestmark = [pytest.mark.unit]
 
@@ -36,14 +36,14 @@ class FakeError(Exception):
     ],
 )
 def test_is_network_error_classifies(message, expected):
-    assert is_network_error(FakeError(message)) is expected
+    assert _is_network_error(FakeError(message)) is expected
 
 
 def test_is_network_error_inspects_cause_chain():
     inner = FakeError("Connection reset by peer")
     outer = FakeError("model call wrapper failed")
     outer.__cause__ = inner
-    assert is_network_error(outer) is True
+    assert _is_network_error(outer) is True
 
 
 @pytest.mark.asyncio
@@ -161,3 +161,70 @@ async def test_non_network_error_retry_succeeds_after_backoff():
 
     assert await mw.awrap_model_call(object(), handler) == "ok"
     assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_network_then_non_network_error_routes_to_parent_retry():
+    """网络异常重试后遇到非网络异常：非网络异常交给父类按 max_retries 重试，最终成功。"""
+    mw = NetworkRetryMiddleware(
+        max_retries=2,
+        network_budget_seconds=30,
+        network_initial_delay=0.0,
+        network_max_delay=0.0,
+        initial_delay=0.0,
+        jitter=False,
+    )
+    calls = {"n": 0}
+
+    async def handler(_request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FakeError("OpenAIConnectionError: Connection error")  # 网络 → wrapped 重试
+        if calls["n"] in (2, 3):
+            raise FakeError("AuthenticationError: invalid api key")  # 非网络 → 交给父类
+        return "ok"  # calls=4
+
+    result = await mw.awrap_model_call(object(), handler)
+
+    assert result == "ok"
+    assert calls["n"] == 4
+
+
+@pytest.mark.asyncio
+async def test_network_budget_survives_parent_retry(monkeypatch):
+    """网络异常 → 非网络异常 → 网络异常：预算起点跨父类重试保持，不被重置放大。"""
+    import yuxi.agents.middlewares.network_retry as module
+
+    clock = {"t": 0.0}
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["t"] += seconds
+
+    monkeypatch.setattr(module, "time", SimpleNamespace(monotonic=lambda: clock["t"]))
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+
+    mw = NetworkRetryMiddleware(
+        max_retries=1,  # 父类非网络重试 1 次
+        network_budget_seconds=5,
+        network_initial_delay=2,
+        network_max_delay=2,
+        initial_delay=0.0,
+        jitter=False,
+    )
+    calls = {"n": 0}
+
+    async def handler(_request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FakeError("OpenAIConnectionError: Connection error")  # 网络，sleep 2
+        if calls["n"] == 2:
+            raise FakeError("AuthenticationError: invalid api key")  # 非网络 → 交给父类
+        raise FakeError("OpenAIConnectionError: Connection error")  # calls=3+ 持续网络
+
+    with pytest.raises(FakeError):
+        await mw.awrap_model_call(object(), handler)
+
+    # 预算起点在包装创建时固定，网络 sleep 累计不超过 5s（不是 5 × 父类重试份数）。
+    assert 0 < sum(sleeps) <= 5

--- a/backend/test/unit/agents/test_network_retry.py
+++ b/backend/test/unit/agents/test_network_retry.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
+from langchain_core.exceptions import ModelError
+from langchain_core.messages import AIMessage
+
 from yuxi.agents.middlewares.network_retry import NetworkRetryMiddleware, is_network_error
 
 pytestmark = [pytest.mark.unit]
@@ -44,7 +48,7 @@ def test_is_network_error_inspects_cause_chain():
 
 @pytest.mark.asyncio
 async def test_retries_network_error_until_success():
-    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.02)
+    mw = NetworkRetryMiddleware(network_budget_seconds=30, network_initial_delay=0.01, network_max_delay=0.02)
     calls = {"n": 0}
 
     async def handler(request):
@@ -59,22 +63,8 @@ async def test_retries_network_error_until_success():
 
 
 @pytest.mark.asyncio
-async def test_non_network_error_propagates_immediately():
-    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.02)
-    calls = {"n": 0}
-
-    async def handler(request):
-        calls["n"] += 1
-        raise FakeError("AuthenticationError: bad key")
-
-    with pytest.raises(FakeError):
-        await mw.awrap_model_call(object(), handler)
-    assert calls["n"] == 1
-
-
-@pytest.mark.asyncio
 async def test_budget_exhaustion_raises():
-    mw = NetworkRetryMiddleware(budget_seconds=0.05, initial_delay=0.03, max_delay=0.03)
+    mw = NetworkRetryMiddleware(network_budget_seconds=0.05, network_initial_delay=0.03, network_max_delay=0.03)
     calls = {"n": 0}
 
     async def handler(request):
@@ -89,7 +79,7 @@ async def test_budget_exhaustion_raises():
 
 @pytest.mark.asyncio
 async def test_cancellation_not_swallowed():
-    mw = NetworkRetryMiddleware(budget_seconds=30, initial_delay=0.01, max_delay=0.01)
+    mw = NetworkRetryMiddleware(network_budget_seconds=30, network_initial_delay=0.01, network_max_delay=0.01)
 
     async def handler(request):
         raise asyncio.CancelledError()
@@ -99,18 +89,41 @@ async def test_cancellation_not_swallowed():
 
 
 @pytest.mark.asyncio
-async def test_composed_middlewares_honor_budget_and_fail_explicitly(monkeypatch):
-    """按真实装配顺序组合两个中间件：预算不被外层重置，耗尽后显式失败而非"假完成"。
+async def test_non_network_error_retried_by_max_retries_then_continue():
+    """非网络错误仍按 max_retries 次数重试，耗尽后 on_failure=continue 返回错误 AIMessage。"""
+    mw = NetworkRetryMiddleware(max_retries=2, initial_delay=0.0, jitter=False)
+    calls = {"n": 0}
 
-    ModelRetryMiddleware 在 NetworkRetryMiddleware 之外（中间件列表排后者为内层）。
-    若外层也重试网络错误，每轮都会开启一个全新的预算(600s × 3)且最终被 on_failure
-    吞成含错误文本的 AIMessage；本用例断言预算只被消费一次且异常显式抛出。
-    """
-    from types import SimpleNamespace
+    async def handler(request):
+        calls["n"] += 1
+        raise FakeError("AuthenticationError: invalid api key")
 
-    from langchain.agents.middleware import ModelRetryMiddleware
-    from yuxi.agents.middlewares import network_retry as network_retry_module
-    from yuxi.agents.middlewares.network_retry import retry_non_network_errors
+    result = await mw.awrap_model_call(object(), handler)
+
+    # max_retries=2 → 1 次初始 + 2 次重试 = 3 次调用
+    assert calls["n"] == 3
+    assert isinstance(result.result[0], AIMessage)
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_model_error_propagates():
+    """非网络错误但不可重试(ModelError.is_retryable=False)时立即抛出，不消耗重试次数。"""
+    mw = NetworkRetryMiddleware(max_retries=2, initial_delay=0.0)
+    calls = {"n": 0}
+
+    async def handler(request):
+        calls["n"] += 1
+        raise ModelError("bad request")  # ModelError.is_retryable 默认为 False
+
+    with pytest.raises(ModelError):
+        await mw.awrap_model_call(object(), handler)
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_network_budget_honored_and_fails_explicitly(monkeypatch):
+    """持续网络错误下，单中间件按预算退避重试，耗尽后显式抛出而非"假完成"。"""
+    import yuxi.agents.middlewares.network_retry as module
 
     clock = {"t": 0.0}
     sleeps: list[float] = []
@@ -119,39 +132,32 @@ async def test_composed_middlewares_honor_budget_and_fail_explicitly(monkeypatch
         sleeps.append(seconds)
         clock["t"] += seconds
 
-    monkeypatch.setattr(network_retry_module, "time", SimpleNamespace(monotonic=lambda: clock["t"]))
-    monkeypatch.setattr(network_retry_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(module, "time", SimpleNamespace(monotonic=lambda: clock["t"]))
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
 
-    inner = NetworkRetryMiddleware(budget_seconds=600, initial_delay=2, max_delay=30)
-    outer = ModelRetryMiddleware(max_retries=2, retry_on=retry_non_network_errors)
+    mw = NetworkRetryMiddleware(network_budget_seconds=600, network_initial_delay=2, network_max_delay=30)
 
-    async def innermost(_request):
+    async def handler(_request):
         raise FakeError("OpenAIConnectionError: Connection error")
 
-    async def handler(request):
-        return await inner.awrap_model_call(request, innermost)
-
     with pytest.raises(FakeError):
-        await outer.awrap_model_call(object(), handler)
+        await mw.awrap_model_call(object(), handler)
 
-    # 总等待受单次预算约束，没有被外层放大成 3 份。
+    # 总等待受单次预算约束，不被放大，且异常显式抛出(没有返回 AIMessage)。
     assert 0 < sum(sleeps) <= 600
 
 
 @pytest.mark.asyncio
-async def test_non_network_error_still_retried_by_outer_model_retry():
-    """非网络错误仍由外层 ModelRetry 按 max_retries 重试，语义未被改变。"""
-    from langchain.agents.middleware import ModelRetryMiddleware
-    from yuxi.agents.middlewares.network_retry import retry_non_network_errors
-
+async def test_non_network_error_retry_succeeds_after_backoff():
+    """非网络错误重试成功后正常返回，语义未被网络重试分支改变。"""
+    mw = NetworkRetryMiddleware(max_retries=2, initial_delay=0.0, jitter=False)
     calls = {"n": 0}
-    outer = ModelRetryMiddleware(max_retries=2, retry_on=retry_non_network_errors, initial_delay=0.0, jitter=False)
 
-    async def handler(_request):
+    async def handler(request):
         calls["n"] += 1
         if calls["n"] < 3:
             raise FakeError("This is a logic bug")
         return "ok"
 
-    assert await outer.awrap_model_call(object(), handler) == "ok"
+    assert await mw.awrap_model_call(object(), handler) == "ok"
     assert calls["n"] == 3

--- a/backend/test/unit/agents/test_network_retry.py
+++ b/backend/test/unit/agents/test_network_retry.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
 from yuxi.agents.middlewares.network_retry import NetworkRetryMiddleware, is_network_error
 
 pytestmark = [pytest.mark.unit]
@@ -97,3 +96,62 @@ async def test_cancellation_not_swallowed():
 
     with pytest.raises(asyncio.CancelledError):
         await mw.awrap_model_call(object(), handler)
+
+
+@pytest.mark.asyncio
+async def test_composed_middlewares_honor_budget_and_fail_explicitly(monkeypatch):
+    """按真实装配顺序组合两个中间件：预算不被外层重置，耗尽后显式失败而非"假完成"。
+
+    ModelRetryMiddleware 在 NetworkRetryMiddleware 之外（中间件列表排后者为内层）。
+    若外层也重试网络错误，每轮都会开启一个全新的预算(600s × 3)且最终被 on_failure
+    吞成含错误文本的 AIMessage；本用例断言预算只被消费一次且异常显式抛出。
+    """
+    from types import SimpleNamespace
+
+    from langchain.agents.middleware import ModelRetryMiddleware
+    from yuxi.agents.middlewares import network_retry as network_retry_module
+    from yuxi.agents.middlewares.network_retry import retry_non_network_errors
+
+    clock = {"t": 0.0}
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+        clock["t"] += seconds
+
+    monkeypatch.setattr(network_retry_module, "time", SimpleNamespace(monotonic=lambda: clock["t"]))
+    monkeypatch.setattr(network_retry_module.asyncio, "sleep", fake_sleep)
+
+    inner = NetworkRetryMiddleware(budget_seconds=600, initial_delay=2, max_delay=30)
+    outer = ModelRetryMiddleware(max_retries=2, retry_on=retry_non_network_errors)
+
+    async def innermost(_request):
+        raise FakeError("OpenAIConnectionError: Connection error")
+
+    async def handler(request):
+        return await inner.awrap_model_call(request, innermost)
+
+    with pytest.raises(FakeError):
+        await outer.awrap_model_call(object(), handler)
+
+    # 总等待受单次预算约束，没有被外层放大成 3 份。
+    assert 0 < sum(sleeps) <= 600
+
+
+@pytest.mark.asyncio
+async def test_non_network_error_still_retried_by_outer_model_retry():
+    """非网络错误仍由外层 ModelRetry 按 max_retries 重试，语义未被改变。"""
+    from langchain.agents.middleware import ModelRetryMiddleware
+    from yuxi.agents.middlewares.network_retry import retry_non_network_errors
+
+    calls = {"n": 0}
+    outer = ModelRetryMiddleware(max_retries=2, retry_on=retry_non_network_errors, initial_delay=0.0, jitter=False)
+
+    async def handler(_request):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise FakeError("This is a logic bug")
+        return "ok"
+
+    assert await outer.awrap_model_call(object(), handler) == "ok"
+    assert calls["n"] == 3

--- a/backend/test/unit/agents/test_summary_graph_config.py
+++ b/backend/test/unit/agents/test_summary_graph_config.py
@@ -65,7 +65,9 @@ async def test_graph_uses_shared_summary_middleware_factory(
     assert captured["summary_context"].summary_threshold == threshold
     assert captured["summary_backend"] is build_args[0]
     middleware_names = [type(middleware).__name__ for middleware in middlewares]
-    assert middleware_names.index("ModelRetryMiddleware") < middleware_names.index("ImageInputCompatibilityMiddleware")
+    assert middleware_names.index("NetworkRetryMiddleware") < middleware_names.index(
+        "ImageInputCompatibilityMiddleware"
+    )
 
 
 @pytest.mark.unit

--- a/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
+++ b/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
@@ -15,12 +15,12 @@ Owner：backend/package/yuxi/agents/middlewares/network_retry.py
 
 ## 决策
 
-网络类错误和非网络类错误的重试维度不同（前者预算、后者次数），必须分开处理，但**不拆成两个中间件**——拆分会因为装配顺序和外层重试网络错误而放大预算。改为让 `NetworkRetryMiddleware` 继承 `ModelRetryMiddleware`，在同一个中间件内区分两类错误：
+网络类错误和非网络类错误的重试维度不同（前者预算、后者次数），必须分开处理，但**不拆成两个中间件**——拆分会因为装配顺序和外层重试网络错误而放大预算。改为让 `NetworkRetryMiddleware` 继承 `ModelRetryMiddleware`，用 **handler 包装**区分两类错误，不复制父类的重试逻辑：
 
-- 网络错误：按 `network_budget_seconds`（默认 600s，环境变量 `YUXI_NETWORK_RETRY_BUDGET_SECONDS`）预算退避重试，耗尽后**显式抛出**（保留 `error_type`/`error_message` 归因，Run 以 `failed` 结束），不经过 `on_failure`；
-- 非网络错误：复用父类的 `max_retries`/`retry_on`（`default_retry_on`）/`on_failure` 语义，与原来 `ModelRetryMiddleware` 行为一致。
+- 网络错误：`_wrap_network_retry`/`_awrap_network_retry` 用闭包包装 handler，在 `network_budget_seconds`（默认 600s，环境变量 `YUXI_NETWORK_RETRY_BUDGET_SECONDS`）预算内吞掉网络异常退避重试，耗尽后**显式抛出**（保留 `error_type`/`error_message` 归因，Run 以 `failed` 结束）；
+- 非网络错误：wrapped handler 原样抛出，交给父类 `wrap_model_call`/`awrap_model_call` 按 `retry_on=_retry_non_network_errors`（排除网络异常、`ModelError.is_retryable` 判定）+ `max_retries`/`on_failure` 处理，与原来 `ModelRetryMiddleware` 行为一致。
 
-同步 `wrap_model_call` 与异步 `awrap_model_call` 对称实现，避免同步路径静默走父类语义而丢失网络预算重试。
+预算起点（`started`）和退避进度（`delay`）在闭包创建时固定，跨父类的非网络重试保持，不会因外层重试而放大成多份。`retry_on` 排除网络异常，保证预算耗尽后的网络错误直接抛出、不被父类再次重试或吞成错误消息。
 
 ## 替代方案
 
@@ -32,13 +32,15 @@ Owner：backend/package/yuxi/agents/middlewares/network_retry.py
 
 网络错误的唯一重试入口是 `NetworkRetryMiddleware` 自身的预算循环，`network_budget_seconds` 是真实上限，不再有外层放大。非网络错误重试语义与 `ModelRetryMiddleware` 一致（`default_retry_on` 的 `ModelError.is_retryable` 判定保留）。
 
-移除了 `retry_non_network_errors` 谓词：合并后不再有外层 `ModelRetryMiddleware` 需要排除网络错误。网络重试参数用 `network_` 前缀（`network_budget_seconds`/`network_initial_delay`/`network_max_delay`）与父类非网络重试的 `initial_delay`/`max_delay` 区分。
+网络重试参数用 `network_` 前缀（`network_budget_seconds`/`network_initial_delay`/`network_max_delay`）与父类非网络重试的 `initial_delay`/`max_delay` 区分。`_is_network_error` 与 `_retry_non_network_errors` 均为模块私有（不再从 `__init__.py` 导出），且只依赖公开的 `ModelError`，不再 import `langchain.agents.middleware._retry` 私有模块。
 
 ## 验证
 
-`backend/test/unit/agents/test_network_retry.py`（20 passed）：
+`backend/test/unit/agents/test_network_retry.py`（22 passed）：
 
 - `test_network_budget_honored_and_fails_explicitly`：虚拟时钟下持续 `ConnectionError`，累计等待受单次 600s 预算约束，最终**抛出**异常而非返回含错误文本的响应；
 - `test_non_network_error_retried_by_max_retries_then_continue`：非网络错误按 `max_retries` 重试后 `on_failure=continue` 返回错误 AIMessage；
 - `test_non_retryable_model_error_propagates`：`ModelError.is_retryable=False` 立即抛出，不消耗重试次数；
-- `test_non_network_error_retry_succeeds_after_backoff`：非网络错误重试成功后正常返回。
+- `test_non_network_error_retry_succeeds_after_backoff`：非网络错误重试成功后正常返回；
+- `test_network_then_non_network_error_routes_to_parent_retry`：网络异常重试后遇到非网络异常，交给父类按 `max_retries` 重试成功；
+- `test_network_budget_survives_parent_retry`：网络 → 非网络 → 网络的序列下，预算起点跨父类重试保持，累计等待不被放大。

--- a/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
+++ b/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
@@ -1,0 +1,41 @@
+# 网络重试预算归属：外层 ModelRetry 不重试网络类错误
+
+状态：implemented
+类型：bug-fix
+Owner：backend/package/yuxi/agents/middlewares/network_retry.py
+
+## 问题
+
+断网时任务应挂起等待恢复，而不是烧尽重试次数后「假完成」（把错误文本写成 assistant 消息、Run 标 completed）。
+
+初版只加了 `NetworkRetryMiddleware`（预算内退避重试）挂在 `ModelRetryMiddleware` 之内，但外层 `ModelRetryMiddleware(max_retries=2)` 仍会重试网络类错误。后果有二：
+
+1. **预算被放大**：`NetworkRetryMiddleware.awrap_model_call` 每次调用都重新记录起始时间，外层每轮重试都会开启一个全新的 600 秒预算，配置的「总预算」实际可重复 `max_retries + 1` 次。
+2. **仍然假完成**：预算耗尽后 `NetworkRetry` 抛出的网络错误被外层 `on_failure="continue"` 吞成含错误文本的 `AIMessage` 并作为成功响应返回。
+
+## 决策
+
+网络重试预算由 `NetworkRetryMiddleware` 独家拥有：外层 `ModelRetryMiddleware` 通过 `retry_on=retry_non_network_errors` 排除网络类错误。
+
+`ModelRetryMiddleware` 对 `retry_on` 返回 `False` 的异常**直接抛出，不经过 `on_failure`**，因此预算耗尽后网络错误按异常显式失败，不再产生「假完成」。
+
+预算耗尽后的失败语义：抛出的仍是原始网络异常（保留 `error_type`/`error_message` 归因），Run 以 `failed` 终态结束。
+
+## 替代方案
+
+- 让预算是进程级/全局共享：会把互不相关的模型调用互相拖累；拒绝。
+- 用请求对象标识跨外层重试共享预算：需要为「同一次模型调用」建立稳定身份，而 `ModelRequest` 无此语义，容易误判；拒绝。
+- 保持现状（外层继续重试网络错误）：预算不可预期且仍有假完成；拒绝。
+
+## 后果
+
+网络错误的唯一重试入口是 `NetworkRetryMiddleware`，其 `budget_seconds` 是真实上限。非网络错误的重试语义不变（仍由 `ModelRetryMiddleware` 按 `max_retries` 处理，`default_retry_on` 的 `ModelError.is_retryable` 判定保留）。
+
+`retry_non_network_errors` 依赖 `langchain.agents.middleware.model_retry.default_retry_on` 保持默认语义；上游若调整该函数，此处同步。
+
+## 验证
+
+`backend/test/unit/agents/test_network_retry.py`：
+
+- `test_composed_middlewares_honor_budget_and_fail_explicitly`：按真实装配顺序组合两个中间件（虚拟时钟），持续 `ConnectionError` 下累计等待受单次 600s 预算约束（未被放大成 3 份），且最终**抛出**异常而非返回含错误文本的响应；
+- `test_non_network_error_still_retried_by_outer_model_retry`：非网络错误仍由外层按 `max_retries` 重试成功，语义未变。

--- a/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
+++ b/docs/develop-guides/decisions/implemented/2026-09-10-network-retry-budget-ownership.md
@@ -1,4 +1,4 @@
-# 网络重试预算归属：外层 ModelRetry 不重试网络类错误
+# 网络重试预算：单中间件内区分网络预算重试与非网络次数重试
 
 状态：implemented
 类型：bug-fix
@@ -8,34 +8,37 @@ Owner：backend/package/yuxi/agents/middlewares/network_retry.py
 
 断网时任务应挂起等待恢复，而不是烧尽重试次数后「假完成」（把错误文本写成 assistant 消息、Run 标 completed）。
 
-初版只加了 `NetworkRetryMiddleware`（预算内退避重试）挂在 `ModelRetryMiddleware` 之内，但外层 `ModelRetryMiddleware(max_retries=2)` 仍会重试网络类错误。后果有二：
+初版拆成两个中间件：`NetworkRetryMiddleware`（预算内退避重试）挂在 `ModelRetryMiddleware` 之内。但外层 `ModelRetryMiddleware(max_retries=2)` 仍会重试网络类错误，后果有二：
 
-1. **预算被放大**：`NetworkRetryMiddleware.awrap_model_call` 每次调用都重新记录起始时间，外层每轮重试都会开启一个全新的 600 秒预算，配置的「总预算」实际可重复 `max_retries + 1` 次。
-2. **仍然假完成**：预算耗尽后 `NetworkRetry` 抛出的网络错误被外层 `on_failure="continue"` 吞成含错误文本的 `AIMessage` 并作为成功响应返回。
+1. **预算被放大**：`NetworkRetryMiddleware.awrap_model_call` 每次调用都重新记录起始时间，外层每轮重试都会开启一个全新的 600 秒预算，实际可重复 `max_retries + 1` 次。
+2. **仍然假完成**：预算耗尽后抛出的网络错误被外层 `on_failure="continue"` 吞成含错误文本的 `AIMessage`。
 
 ## 决策
 
-网络重试预算由 `NetworkRetryMiddleware` 独家拥有：外层 `ModelRetryMiddleware` 通过 `retry_on=retry_non_network_errors` 排除网络类错误。
+网络类错误和非网络类错误的重试维度不同（前者预算、后者次数），必须分开处理，但**不拆成两个中间件**——拆分会因为装配顺序和外层重试网络错误而放大预算。改为让 `NetworkRetryMiddleware` 继承 `ModelRetryMiddleware`，在同一个中间件内区分两类错误：
 
-`ModelRetryMiddleware` 对 `retry_on` 返回 `False` 的异常**直接抛出，不经过 `on_failure`**，因此预算耗尽后网络错误按异常显式失败，不再产生「假完成」。
+- 网络错误：按 `network_budget_seconds`（默认 600s，环境变量 `YUXI_NETWORK_RETRY_BUDGET_SECONDS`）预算退避重试，耗尽后**显式抛出**（保留 `error_type`/`error_message` 归因，Run 以 `failed` 结束），不经过 `on_failure`；
+- 非网络错误：复用父类的 `max_retries`/`retry_on`（`default_retry_on`）/`on_failure` 语义，与原来 `ModelRetryMiddleware` 行为一致。
 
-预算耗尽后的失败语义：抛出的仍是原始网络异常（保留 `error_type`/`error_message` 归因），Run 以 `failed` 终态结束。
+同步 `wrap_model_call` 与异步 `awrap_model_call` 对称实现，避免同步路径静默走父类语义而丢失网络预算重试。
 
 ## 替代方案
 
+- 保留两个中间件（内层 `NetworkRetry` + 外层 `ModelRetry`，用 `retry_on` 谓词排除网络错误）：功能等价，但装配绕、且「网络错误不归外层管」这个不变量靠装配顺序+谓词两处共同维持，一处漏改就重新放大预算；采纳作者「合并成单中间件」的建议后拒绝。
 - 让预算是进程级/全局共享：会把互不相关的模型调用互相拖累；拒绝。
-- 用请求对象标识跨外层重试共享预算：需要为「同一次模型调用」建立稳定身份，而 `ModelRequest` 无此语义，容易误判；拒绝。
-- 保持现状（外层继续重试网络错误）：预算不可预期且仍有假完成；拒绝。
+- 用请求对象标识跨外层重试共享预算：需要为「同一次模型调用」建立稳定身份，而 `ModelRequest` 无此语义；拒绝。
 
 ## 后果
 
-网络错误的唯一重试入口是 `NetworkRetryMiddleware`，其 `budget_seconds` 是真实上限。非网络错误的重试语义不变（仍由 `ModelRetryMiddleware` 按 `max_retries` 处理，`default_retry_on` 的 `ModelError.is_retryable` 判定保留）。
+网络错误的唯一重试入口是 `NetworkRetryMiddleware` 自身的预算循环，`network_budget_seconds` 是真实上限，不再有外层放大。非网络错误重试语义与 `ModelRetryMiddleware` 一致（`default_retry_on` 的 `ModelError.is_retryable` 判定保留）。
 
-`retry_non_network_errors` 依赖 `langchain.agents.middleware.model_retry.default_retry_on` 保持默认语义；上游若调整该函数，此处同步。
+移除了 `retry_non_network_errors` 谓词：合并后不再有外层 `ModelRetryMiddleware` 需要排除网络错误。网络重试参数用 `network_` 前缀（`network_budget_seconds`/`network_initial_delay`/`network_max_delay`）与父类非网络重试的 `initial_delay`/`max_delay` 区分。
 
 ## 验证
 
-`backend/test/unit/agents/test_network_retry.py`：
+`backend/test/unit/agents/test_network_retry.py`（20 passed）：
 
-- `test_composed_middlewares_honor_budget_and_fail_explicitly`：按真实装配顺序组合两个中间件（虚拟时钟），持续 `ConnectionError` 下累计等待受单次 600s 预算约束（未被放大成 3 份），且最终**抛出**异常而非返回含错误文本的响应；
-- `test_non_network_error_still_retried_by_outer_model_retry`：非网络错误仍由外层按 `max_retries` 重试成功，语义未变。
+- `test_network_budget_honored_and_fails_explicitly`：虚拟时钟下持续 `ConnectionError`，累计等待受单次 600s 预算约束，最终**抛出**异常而非返回含错误文本的响应；
+- `test_non_network_error_retried_by_max_retries_then_continue`：非网络错误按 `max_retries` 重试后 `on_failure=continue` 返回错误 AIMessage；
+- `test_non_retryable_model_error_propagates`：`ModelError.is_retryable=False` 立即抛出，不消耗重试次数；
+- `test_non_network_error_retry_succeeds_after_backoff`：非网络错误重试成功后正常返回。


### PR DESCRIPTION
## 现象

断网时，模型调用报 `OpenAIConnectionError`，`ModelRetryMiddleware` 只重试 3 次就放弃，把错误文本写成 assistant 消息、Run 标记 completed。用户恢复网络后，任务已经「假完成」，还得手动重来。

## 对标

Claude Code 断网恢复后能自动继续——网络错误不烧尽重试预算、按退避持续重试、重试期间任务挂起而非取消。

## 机理

现有的 `ModelRetryMiddleware(max_retries=2)` 对所有错误一视同仁，都只重试固定次数。但网络错误是**可自愈**的（恢复后重试就成功），逻辑错误**不可自愈**（重试也没用），两者没有区分。

## 改进方法

新增 `NetworkRetryMiddleware`，挂在 `ModelRetryMiddleware` **内层**（先拦截异常）：

- 按异常类名 + 消息关键词识别网络类错误（connection/timeout/5xx），排除 ratelimit/auth/invalid_request；
- 网络类错误指数退避重试（2s→30s 封顶），总预算 `YUXI_NETWORK_RETRY_BUDGET_SECONDS`（默认 600s）内不抛错；
- 预算耗尽或非网络错误透传原语义；`CancelledError` 不吞。

> 中间件顺序是关键：langchain 中间件列表排后者为内层（先拦截），必须放 `ModelRetry` 之内——`ModelRetry` 默认 `on_failure=continue` 会把异常吞成错误 AIMessage，`NetworkRetry` 若在外层就永远看不到网络异常。

## 效果

断网 100+ 秒任务保持 running，恢复后自动继续完成，零干预；正常逻辑错误仍按原语义快速失败。附 6 个单测覆盖错误分类、退避重试成功、非网络错误透传、预算耗尽、取消不吞。