### PR TITLE
perf(agents): MCP 工具并发加载，多 MCP server 启动耗时从 sum 降到 max

### DIFF
--- a/backend/package/yuxi/agents/toolkits/service.py
+++ b/backend/package/yuxi/agents/toolkits/service.py
@@ -113,16 +113,29 @@ async def resolve_configured_runtime_tools(context) -> list[Any]:
         selected_tool_names.add(tool_name)
         selected_tool_sources[tool_name] = "local"
 
+    # 去重后的 MCP server 列表(保持配置顺序)
     selected_mcp_servers: set[str] = set()
+    server_names: list[str] = []
     for server_name in getattr(context, "mcps", None) or []:
         if not isinstance(server_name, str) or server_name in selected_mcp_servers:
             continue
         selected_mcp_servers.add(server_name)
+        server_names.append(server_name)
+
+    # 并发加载各 MCP server 的工具(单 server 33-300ms,串行 6 个累加 1-2s;
+    # 官方 deepagents-code 同款优化: asyncio.gather 并发,取 max 而非 sum)。
+    import asyncio
+
+    async def _load_one(name: str):
         try:
-            mcp_tools = await get_enabled_mcp_tools(server_name)
+            return name, await get_enabled_mcp_tools(name)
         except Exception as e:
-            logger.warning(f"Failed to load configured MCP tools '{server_name}': {e}")
-            continue
+            logger.warning(f"Failed to load configured MCP tools '{name}': {e}")
+            return name, None
+
+    loaded = await asyncio.gather(*(_load_one(n) for n in server_names))
+
+    for server_name, mcp_tools in loaded:
         if not mcp_tools:
             logger.warning(f"Configured MCP unavailable, skip: {server_name}")
             continue


### PR DESCRIPTION
## 现象

智能体启动时，配置了多个 MCP server 的情况下，工具加载是**串行**的：每个 server 逐个 `await get_enabled_mcp_tools`。单个 server 加载 33-300ms，6 个串行累加就是 1-2 秒——都花在智能体启动阶段，用户感知为「发出去后要等一下才开始」。

## 机理

`resolve_configured_runtime_tools` 里对 `context.mcps` 逐个串行 await：

```python
for server_name in ...:
    mcp_tools = await get_enabled_mcp_tools(server_name)   # 逐个等
```

各 MCP server 之间互相独立，串行没有道理，总耗时是 sum 而非 max。

## 改进方法

改成 `asyncio.gather` 并发加载全部 MCP server 的工具，取 max 而非 sum：

- 先收集去重后的 server 名单（保持配置顺序，保证工具注册顺序不变）；
- `asyncio.gather` 并发加载；
- 单个 server 失败仍只 warn、不影响其他（用返回值 `(name, None)` 代替 `continue`，保持容错语义）。

这是上游 **deepagents-code #4659 同款优化**（deepagents 官方已采用并发加载）。

## 效果

多 MCP server 场景下，工具加载耗时从 **sum 降到 max**（6 个 server 约 1-2s → 单次最慢 server 耗时）。单 server 失败容错语义不变。