### PR TITLE
fix(web): run 流增加无事件看门狗，SSE 悬挂不再永转 loading

### DIFF
--- a/web/src/composables/useAgentRunStream.js
+++ b/web/src/composables/useAgentRunStream.js
@@ -321,6 +321,26 @@ export function useAgentRunStream({
     }
     const touchedThreadIds = new Set([threadId])
     let sawTerminalEvent = false
+    // 无事件看门狗: SSE 连接悬挂(断线窗口错过 end 事件且连接未关闭)时,
+    // 主动查询 run 终态并收尾,避免 loading 永转
+    let lastEventAt = Date.now()
+    const idleWatchdog = setInterval(async () => {
+      if (sawTerminalEvent || ts.activeRunId !== runId) {
+        clearInterval(idleWatchdog)
+        return
+      }
+      if (Date.now() - lastEventAt < 45000) return
+      try {
+        const runRes = await agentApi.getAgentRun(runId)
+        const st = runRes?.run?.status
+        if (st && RUN_TERMINAL_STATUSES.has(st)) {
+          clearInterval(idleWatchdog)
+          finalizeRunStream(threadId, runId, touchedThreadIds, { status: st })
+        }
+      } catch {
+        // 查询失败忽略,下轮再看
+      }
+    }, 30000)
 
     try {
       const response = await agentApi.streamAgentRunEvents(runId, ts.runLastSeq, {
@@ -332,6 +352,7 @@ export function useAgentRunStream({
 
       await processRunSseResponse(response, (event, data, eventId) => {
         if (!data || ts.activeRunId !== runId) return
+        lastEventAt = Date.now()
 
         if (eventId) {
           const incomingSeq = normalizeRunSeq(eventId)
@@ -429,6 +450,7 @@ export function useAgentRunStream({
         scheduleRunReconnect(threadId, runId)
       }
     } finally {
+      clearInterval(idleWatchdog)
       if (ts.runStreamAbortController === runController) {
         ts.runStreamAbortController = null
       }


### PR DESCRIPTION
## 现象

偶发情况下，SSE run 流会**悬挂**：连接没关闭，但也不再推任何事件（例如断线窗口恰好错过了 `end` 事件，连接却停留在打开状态）。此时前端 `isReplyLoading` 永远为 true，**loading 一直转**，用户只能手刷页面。

## 机理

前端完全依赖 SSE 事件驱动收尾：只有收到 `end`（或终态）事件才 `finalizeRunStream`。一旦「终态事件丢了 + 连接没关」这个组合出现，就没有任何兜底路径——没有事件 = 永远等下去。

## 改进方法

在 `processRunSseResponse` 之外加一个**无事件看门狗**：

- 记录 `lastEventAt`，每收到一个事件就刷新；
- `setInterval` 30s 检查一次：若距上次事件超过 45s 且 run 仍是当前活跃 run，则主动 `agentApi.getAgentRun(runId)` 查一次权威状态；
- 若查到终态（completed/failed/cancelled），立即 `finalizeRunStream` 收尾，并清理看门狗；
- 查询失败忽略，下轮再看（不因看门狗本身出错而影响主流程）；
- `finally` 里统一 `clearInterval`，避免泄漏。

## 效果

SSE 悬挂时前端最多 45s 后自动收尾，不再永转 loading；正常流式不受影响（有事件时看门狗不触发）。这是一个纯兜底 guard，不改变正常路径语义。