### PR TITLE
fix: 统一回答反馈的目标校验与前端入口

### DIFF
--- a/backend/package/yuxi/services/feedback_service.py
+++ b/backend/package/yuxi/services/feedback_service.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from yuxi.services.langfuse_service import submit_user_feedback_score
-from yuxi.storage.postgres.models_business import Conversation, Message, MessageFeedback
+from yuxi.storage.postgres.models_business import AUDIT_MESSAGE_TYPES, Conversation, Message, MessageFeedback
 from yuxi.utils.logging_config import logger
 
 
@@ -29,6 +29,9 @@ async def submit_message_feedback_view(
         conversation = conversation_result.scalar_one_or_none()
         if not conversation or conversation.uid != str(current_uid):
             raise HTTPException(status_code=403, detail="Access denied")
+
+        if message.role != "assistant" or message.message_type in AUDIT_MESSAGE_TYPES:
+            raise HTTPException(status_code=422, detail="Feedback is only supported for non-audit assistant messages")
 
         existing_feedback_result = await db.execute(
             select(MessageFeedback).filter_by(message_id=message_id, uid=str(current_uid))

--- a/backend/test/integration/api/test_feedback_router.py
+++ b/backend/test/integration/api/test_feedback_router.py
@@ -1,0 +1,110 @@
+"""通过真实 HTTP 与 PostgreSQL 验证反馈目标及持久化结果。"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from yuxi.storage.postgres.models_business import Conversation, Message, MessageFeedback, Project
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+async def test_feedback_target_contract(test_client, admin_headers):
+    """非法角色和审计行零落库，普通及旧版助手消息保持可反馈。"""
+    current_user = await test_client.get("/api/auth/me", headers=admin_headers)
+    assert current_user.status_code == 200, current_user.text
+    uid = str(current_user.json()["uid"])
+    project_id = str(uuid.uuid4())
+    thread_id = str(uuid.uuid4())
+    engine = create_async_engine(os.environ["POSTGRES_URL"])
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    message_ids = []
+    conversation_id = None
+    cases = [
+        ("user", "text", 422),
+        ("system", "text", 422),
+        ("tool", "text", 422),
+        ("assistant", "model_audit", 422),
+        ("assistant", "tool_audit", 422),
+        ("assistant", "text", 200),
+        ("assistant", None, 200),
+    ]
+    try:
+        async with factory() as db:
+            db.add(
+                Project(
+                    id=project_id,
+                    uid=uid,
+                    selection_status="implicit",
+                    workdir_path=f"pytest-feedback/{project_id}",
+                    directory_mode="managed",
+                )
+            )
+            await db.flush()
+            conversation = Conversation(
+                thread_id=thread_id,
+                uid=uid,
+                agent_id="pytest-feedback",
+                project_id=project_id,
+                title="pytest feedback target contract",
+            )
+            db.add(conversation)
+            await db.flush()
+            conversation_id = conversation.id
+            for role, message_type, _ in cases:
+                message = Message(
+                    conversation_id=conversation_id,
+                    role=role,
+                    message_type=message_type,
+                    content="feedback target fixture",
+                    extra_metadata={},
+                )
+                db.add(message)
+                await db.flush()
+                message_ids.append(message.id)
+            # ORM 插入时的默认值会覆盖 None；显式 SQL NULL 才证明旧数据兼容。
+            await db.execute(update(Message).where(Message.id == message_ids[-1]).values(message_type=None))
+            await db.commit()
+
+        for (_, _, expected), message_id in zip(cases, message_ids, strict=True):
+            response = await test_client.post(
+                f"/api/chat/message/{message_id}/feedback",
+                headers=admin_headers,
+                json={"rating": "like"},
+            )
+            assert response.status_code == expected, response.text
+            async with factory() as db:
+                rows = (await db.scalars(select(MessageFeedback).where(MessageFeedback.message_id == message_id))).all()
+            assert len(rows) == int(expected == 200)
+            if expected == 200:
+                assert rows[0].id == response.json()["id"]
+                assert rows[0].uid == uid
+                assert rows[0].rating == "like"
+            else:
+                assert response.json()["detail"] == "Feedback is only supported for non-audit assistant messages"
+
+        duplicate = await test_client.post(
+            f"/api/chat/message/{message_ids[-1]}/feedback",
+            headers=admin_headers,
+            json={"rating": "dislike"},
+        )
+        assert duplicate.status_code == 409, duplicate.text
+        async with factory() as db:
+            rows = (await db.scalars(select(MessageFeedback).where(MessageFeedback.message_id.in_(message_ids)))).all()
+        assert len(rows) == 2
+        assert all(row.rating == "like" for row in rows)
+    finally:
+        async with factory() as db:
+            if message_ids:
+                await db.execute(delete(MessageFeedback).where(MessageFeedback.message_id.in_(message_ids)))
+                await db.execute(delete(Message).where(Message.id.in_(message_ids)))
+            if conversation_id is not None:
+                await db.execute(delete(Conversation).where(Conversation.id == conversation_id))
+            await db.execute(delete(Project).where(Project.id == project_id))
+            await db.commit()
+        await engine.dispose()

--- a/backend/test/unit/services/test_feedback_service.py
+++ b/backend/test/unit/services/test_feedback_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from yuxi.services import feedback_service as svc
 
@@ -45,6 +46,8 @@ async def test_submit_message_feedback_syncs_langfuse_score(monkeypatch: pytest.
     message = SimpleNamespace(
         id=3,
         conversation_id=7,
+        role="assistant",
+        message_type="text",
         extra_metadata={"langfuse_trace_id": "trace-1"},
     )
     conversation = SimpleNamespace(id=7, uid="user-1")
@@ -84,8 +87,9 @@ async def test_submit_message_feedback_syncs_langfuse_score(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
-async def test_submit_message_feedback_skips_langfuse_without_trace_id(monkeypatch: pytest.MonkeyPatch):
-    message = SimpleNamespace(id=3, conversation_id=7, extra_metadata={})
+@pytest.mark.parametrize("message_type", ["text", None])
+async def test_submit_message_feedback_skips_langfuse_without_trace_id(monkeypatch: pytest.MonkeyPatch, message_type):
+    message = SimpleNamespace(id=3, conversation_id=7, role="assistant", message_type=message_type, extra_metadata={})
     conversation = SimpleNamespace(id=7, uid="user-1")
     db = _FakeSession([message, conversation, None])
     calls = []
@@ -102,4 +106,82 @@ async def test_submit_message_feedback_skips_langfuse_without_trace_id(monkeypat
 
     assert result["rating"] == "dislike"
     assert result["reason"] == "不相关"
+    assert db.committed is True
+    assert len(db.added) == 1
+    assert db.added[0].message_id == 3
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("role", "message_type"),
+    [
+        ("user", "text"),
+        ("system", "text"),
+        ("tool", "text"),
+        ("assistant", "model_audit"),
+        ("assistant", "tool_audit"),
+    ],
+)
+async def test_submit_message_feedback_rejects_invalid_target_without_side_effects(monkeypatch, role, message_type):
+    """非助手与审计消息在写入、上传评分前被拒绝。"""
+    message = SimpleNamespace(
+        id=3,
+        conversation_id=7,
+        role=role,
+        message_type=message_type,
+        extra_metadata={"langfuse_trace_id": "trace-invalid"},
+    )
+    db = _FakeSession([message, SimpleNamespace(id=7, uid="user-1")])
+    calls = []
+    monkeypatch.setattr(svc, "submit_user_feedback_score", lambda **kwargs: calls.append(kwargs))
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.submit_message_feedback_view(message_id=3, rating="like", reason=None, db=db, current_uid="user-1")
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Feedback is only supported for non-audit assistant messages"
+    assert db.added == []
+    assert db.committed is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "status", "detail"),
+    [
+        ("missing", 404, "Message not found"),
+        ("foreign", 403, "Access denied"),
+        ("missing_conversation", 403, "Access denied"),
+        ("duplicate", 409, "Feedback already submitted for this message"),
+    ],
+)
+async def test_submit_message_feedback_preserves_existing_errors(monkeypatch, case, status, detail):
+    """保留缺失、所有权与重复反馈错误，所有权检查优先于目标检查。"""
+    message = SimpleNamespace(
+        id=3,
+        conversation_id=7,
+        role="assistant" if case == "duplicate" else "user",
+        message_type="text",
+        extra_metadata={"langfuse_trace_id": "trace-1"},
+    )
+    if case == "missing":
+        results = [None]
+    elif case == "foreign":
+        results = [message, SimpleNamespace(id=7, uid="other-user")]
+    elif case == "missing_conversation":
+        results = [message, None]
+    else:
+        results = [message, SimpleNamespace(id=7, uid="user-1"), SimpleNamespace(id=9)]
+    db = _FakeSession(results)
+    calls = []
+    monkeypatch.setattr(svc, "submit_user_feedback_score", lambda **kwargs: calls.append(kwargs))
+
+    with pytest.raises(HTTPException) as exc:
+        await svc.submit_message_feedback_view(message_id=3, rating="like", reason=None, db=db, current_uid="user-1")
+
+    assert exc.value.status_code == status
+    assert exc.value.detail == detail
+    assert db.added == []
+    assert db.committed is False
     assert calls == []

--- a/docs/develop-guides/decisions/proposed/2026-09-12-feedback-target-contract.md
+++ b/docs/develop-guides/decisions/proposed/2026-09-12-feedback-target-contract.md
@@ -1,0 +1,30 @@
+# 回答反馈目标契约
+
+状态：proposed
+类型：bug-fix
+Owner：backend/package/yuxi/services/feedback_service.py
+
+## 问题
+反馈写入口只校验归属，用户、系统、工具与助手审计记录均可进入反馈写路径；界面面向助手回答，统计排除审计类型，含义不一致。
+
+## 提案
+后端与前端实现已在独立分支建立；合并前仍需维护者确认新增422行为（隔离完整live集成已通过）。既有消息存在和会话归属校验之后，要求role为assistant且message_type不属于AUDIT_MESSAGE_TYPES，兼容历史None类型。不要求执行成功，中断但已发布的回答继续支持。非法目标返回422，先于数据库写入与外部评分。
+
+前端隐藏审计消息反馈按钮，保留模型、复制和来源。显式role优先，历史无role使用type=ai；显式status要求finished，历史无status沿用父组件既有收尾控制。点击与模态框提交也检查目标，避免目标变化后误发请求。
+
+## 替代方案
+只限制角色会遗漏assistant/model_audit。强制role/status会破坏真实历史DTO；限制全部completed会排除中断回答。数据库约束或历史清理扩大迁移影响，本提案不采用。
+
+## 验收标准
+| 验收主张 | 失败面 | 语义 Owner | 直接证据 / 命令 | 负向案例 | 当前结果 |
+|---|---|---|---|---|---|
+| 非法目标零写入和零评分 | 角色及审计类型 | feedback_service | test_feedback_service.py，12例 | user/system/tool及审计 | Passed |
+| 合法及历史目标兼容 | text/None | feedback_service | 同上 | 403/404/409保持 | Passed |
+| 路由与持久化结果一致 | HTTP/数据库 | chat路由/反馈服务 | 独立ASGITransport+PostgreSQL探针 | 5非法目标零记录 | Passed |
+| 前端反馈目标一致 | 真实历史DTO及属性切换 | RefsComponent | refs_feedback_target.test.js，12静态场景及运行时交互；浏览器组件页面 | 审计、用户、loading与打开弹窗后变更 | Passed |
+| 标准live集成完整执行 | 部署认证及应用启动 | chat路由 | test/integration/api/test_feedback_router.py | 7目标与重复提交 | Passed（1项循环7目标，真实登录及清理） |
+
+## 风险
+ASGI探针使用真实路由和PostgreSQL，仅替换认证身份、数据库依赖及外部评分，不证明完整登录或TCP应用启动。前端测试保留真实模板，隔离无关依赖；浏览器是组件验收页而非生产会话。后端全量2004通过，工程检查器62通过；Linux全Web320通过，Windows此前319通过/1失败（未改动PDF测试路径）。全lint在两平台均有未改动PDF测试Buffer未定义2项；本次两文件lint通过，build通过。历史数据和统计口径不调整。提案公开前需审阅完整diff，不将局部验证写成全套CI通过。
+
+标准live通过完整TCP应用、真实登录、schema门禁与原清理fixtures；隔离PostgreSQL/Redis，provisioner采用memory后端，未验证容器沙箱执行。实际运行测试与最终暂存版仅格式差异，AST一致；服务代码字节一致。

--- a/web/src/components/RefsComponent.vue
+++ b/web/src/components/RefsComponent.vue
@@ -3,6 +3,7 @@
     <div class="tags">
       <!-- 反馈 -->
       <span
+        v-if="canSubmitFeedback"
         class="item btn"
         :class="{ disabled: feedbackState.hasSubmitted }"
         @click="likeThisResponse(msg)"
@@ -11,6 +12,7 @@
         <ThumbsUp size="12" :fill="feedbackState.rating === 'like' ? 'currentColor' : 'none'" />
       </span>
       <span
+        v-if="canSubmitFeedback"
         class="item btn"
         :class="{ disabled: feedbackState.hasSubmitted }"
         @click="dislikeThisResponse(msg)"
@@ -147,6 +149,15 @@ const props = defineProps({
 
 const msg = ref(props.message)
 
+const canSubmitFeedback = computed(
+  () =>
+    (msg.value?.role
+      ? ['assistant', 'received'].includes(msg.value.role)
+      : msg.value?.type === 'ai') &&
+    (!msg.value?.status || msg.value.status === 'finished') &&
+    !['model_audit', 'tool_audit'].includes(msg.value?.message_type)
+)
+
 // Sources state
 const isSourcesExpanded = ref(false)
 
@@ -279,6 +290,7 @@ const getModelName = (msg) => {
 }
 // Handle like action
 const likeThisResponse = async (msg) => {
+  if (!canSubmitFeedback.value) return
   if (feedbackState.hasSubmitted) {
     antMessage.info('您已经提交过反馈了')
     return
@@ -313,6 +325,7 @@ const likeThisResponse = async (msg) => {
 
 // Handle dislike action
 const dislikeThisResponse = async (msg) => {
+  if (!canSubmitFeedback.value) return
   if (feedbackState.hasSubmitted) {
     antMessage.info('您已经提交过反馈了')
     return
@@ -330,6 +343,7 @@ const dislikeThisResponse = async (msg) => {
 
 // Submit dislike feedback with reason
 const submitDislikeFeedback = async () => {
+  if (!canSubmitFeedback.value) return
   try {
     submittingFeedback.value = true
     await agentApi.submitMessageFeedback(msg.value.id, 'dislike', dislikeReason.value || null)
@@ -460,7 +474,6 @@ const cancelDislike = () => {
         }
       }
     }
-
   }
 
   .sources-panel-body {

--- a/web/test/unit/refs_feedback_target.test.js
+++ b/web/test/unit/refs_feedback_target.test.js
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { compileScript, parse } from 'vue/compiler-sfc'
+import { createSSRApp, createRenderer, h, nextTick, ref } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { createServer } from 'vite'
+
+// 编译真实模板，仅隔离无关网络、剪贴板和来源子组件。
+test('反馈按钮只面向完成的非审计助手，模型与复制操作保持', async () => {
+  const server = await createServer({
+    configFile: false,
+    server: { middlewareMode: true, hmr: false },
+    appType: 'custom',
+    plugins: [
+      {
+        name: 'refs-feedback-fixture',
+        resolveId(id) {
+          if (id === 'virtual:refs-feedback') return '\0' + id
+          if (
+            id === '@vueuse/core' ||
+            id === 'ant-design-vue' ||
+            id === '@lucide/vue' ||
+            id.startsWith('@/')
+          )
+            return '\0stub:' + id
+        },
+        load(id) {
+          if (id === '\0virtual:refs-feedback') {
+            const source = readFileSync(
+              new URL('../../src/components/RefsComponent.vue', import.meta.url),
+              'utf8'
+            )
+            return compileScript(parse(source).descriptor, {
+              id: 'refs-feedback',
+              inlineTemplate: true
+            }).content
+          }
+          if (!id.startsWith('\0stub:')) return
+          if (id.endsWith('@vueuse/core'))
+            return 'export const useClipboard = () => ({ copy: async () => {}, isSupported: true })'
+          if (id.endsWith('ant-design-vue'))
+            return 'export const message = { info() {}, success() {}, error() {} }'
+          if (id.endsWith('@lucide/vue'))
+            return 'export const ThumbsUp = {}, ThumbsDown = {}, Bot = {}, Copy = {}, Check = {}, RotateCcw = {}, BookOpen = {}, ChevronDown = {}'
+          if (id.endsWith('@/apis'))
+            return 'export const calls = []; export const agentApi = { submitMessageFeedback(...args) { calls.push(args); return Promise.resolve() } }'
+          if (id.endsWith('@/utils/time')) return 'export const formatChatTime = () => ""'
+          if (id.endsWith('@/utils/runTiming'))
+            return 'export const formatRunTimingDuration = () => ""; export const getRunTotalLatencyMs = () => null'
+          return 'export default { render() { return null } }'
+        }
+      }
+    ]
+  })
+  try {
+    const { default: Refs } = await server.ssrLoadModule('virtual:refs-feedback')
+    const cases = [
+      ['assistant', 'text', 'finished', true],
+      ['received', null, 'finished', true],
+      ['assistant', undefined, 'finished', true],
+      [undefined, 'text', undefined, true],
+      [undefined, null, undefined, true],
+      [undefined, 'model_audit', undefined, false],
+      ['assistant', 'text', 'loading', false],
+      ['assistant', 'model_audit', 'finished', false],
+      ['assistant', 'tool_audit', 'finished', false],
+      ['user', 'text', 'finished', false],
+      ['system', 'text', 'finished', false],
+      ['tool', 'text', 'finished', false]
+    ]
+    for (const [role, messageType, status, allowed] of cases) {
+      const app = createSSRApp(Refs, {
+        message: {
+          id: 1,
+          type: 'ai',
+          role,
+          message_type: messageType,
+          status,
+          content: 'fixture',
+          response_metadata: { model_name: 'fixture-model' }
+        },
+        showRefs: ['model', 'copy']
+      })
+      app.config.warnHandler = () => {}
+      app.component('a-modal', {
+        render() {
+          return null
+        }
+      })
+      app.component('a-textarea', {
+        render() {
+          return null
+        }
+      })
+      const html = await renderToString(app)
+      assert.equal(html.includes('title="点赞"'), allowed, `${role}/${messageType}/${status}`)
+      assert.equal(html.includes('title="点踩"'), allowed)
+      assert.ok(html.includes('fixture-model'))
+      assert.ok(html.includes('title="复制"'))
+    }
+    const makeNode = (type) => ({ type, children: [], props: {}, parent: null })
+    const renderer = createRenderer({
+      createElement: makeNode,
+      createText: (text) => ({ ...makeNode('text'), text }),
+      createComment: (text) => ({ ...makeNode('comment'), text }),
+      insert(child, parent, anchor = null) {
+        child.parent = parent
+        const index = anchor ? parent.children.indexOf(anchor) : -1
+        if (index < 0) parent.children.push(child)
+        else parent.children.splice(index, 0, child)
+      },
+      remove(child) {
+        child.parent.children.splice(child.parent.children.indexOf(child), 1)
+      },
+      setText(node, text) {
+        node.text = text
+      },
+      setElementText(node, text) {
+        node.text = text
+        node.children = []
+      },
+      parentNode: (node) => node.parent,
+      nextSibling: (node) => node.parent?.children[node.parent.children.indexOf(node) + 1] || null,
+      patchProp(node, key, _old, value) {
+        node.props[key] = value
+      }
+    })
+    const find = (node, predicate) =>
+      predicate(node) ? node : node.children.map((child) => find(child, predicate)).find(Boolean)
+    const current = ref({
+      id: 1,
+      type: 'ai',
+      role: 'assistant',
+      status: 'loading',
+      message_type: 'text'
+    })
+    const app = renderer.createApp(() =>
+      h(Refs, { message: current.value, showRefs: ['model', 'copy'] })
+    )
+    app.config.warnHandler = () => {}
+    app.component('a-modal', {
+      render() {
+        return h('modal-fixture', this.$attrs)
+      }
+    })
+    app.component('a-textarea', {
+      render() {
+        return null
+      }
+    })
+    const host = makeNode('root')
+    app.mount(host)
+    try {
+      assert.equal(
+        find(host, (node) => node.props.title === '点赞'),
+        undefined
+      )
+      current.value = { ...current.value, status: 'finished' }
+      await nextTick()
+      assert.ok(find(host, (node) => node.props.title === '点赞'))
+      const dislike = find(host, (node) => node.props.title === '点踩')
+      dislike.props.onClick()
+      await nextTick()
+      assert.equal(find(host, (node) => node.type === 'modal-fixture').props.open, true)
+      current.value = { ...current.value, message_type: 'model_audit' }
+      await nextTick()
+      assert.equal(
+        find(host, (node) => node.props.title === '点赞'),
+        undefined
+      )
+      // 模态框已打开后目标变成审计行，提交仍须在API前停止。
+      await find(host, (node) => node.type === 'modal-fixture').props.onOk()
+      await nextTick()
+      assert.equal(find(host, (node) => node.type === 'modal-fixture').props.confirmLoading, false)
+      const { calls } = await server.ssrLoadModule('@/apis')
+      assert.equal(calls.length, 0)
+    } finally {
+      app.unmount()
+    }
+  } finally {
+    await server.close()
+  }
+})


### PR DESCRIPTION
## 变更说明

- 任务类型：bug-fix；substantial（收紧反馈写入口的目标契约）。
- 目标：仅对本人会话的非审计 assistant 消息提交反馈，前端入口与服务校验一致，兼容历史 None 类型及无 role/status 的历史 DTO。
- 非目标：清理历史反馈、改变 Dashboard/GET 权限、重构运行终态；不包含其他 PR 的重排修复。

## 工程主张与 Owner

feedback_service 在消息存在和归属检查后、数据库写入与外部评分前校验角色/审计类型；非法目标返回 422，保留 403/404/409。RefsComponent 隐藏非法目标的点赞/点踩入口，并在点击及弹窗提交时复核目标，保留复制、模型和来源。
决策记录：[回答反馈目标契约](https://github.com/zhujue888/Yuxi/blob/78de2ab63ab2f717032d100de54b35e036575f8e/docs/develop-guides/decisions/proposed/2026-09-12-feedback-target-contract.md)。新增 422 行为仍请维护者确认，decision 保留 proposed。

## 验证情况

| 主张 | 失败面 | 语义 Owner | 直接证据 / 命令 | 负向案例 | 结果 |
|---|---|---|---|---|---|
| 非法目标零写入/零评分 | 角色/审计类型 | feedback_service | test/unit/services/test_feedback_service.py，12项 | user/system/tool、两类审计；原服务5失败、修复后12通过 | Passed |
| 合法历史兼容与既有错误 | text/None及归属 | feedback_service | 同上 | 403/404/409保持 | Passed |
| 完整HTTP登录与持久化 | 应用启动/认证/schema/清理 | chat路由 | test/integration/api/test_feedback_router.py，1项循环7种目标及重复提交；隔离PostgreSQL/Redis、完整TCP应用、原fixtures | 5类非法目标拒绝，合法text/SQL NULL成功，重复409 | Passed |
| 前端反馈入口与提交一致 | 历史DTO、属性切换 | RefsComponent | test/unit/refs_feedback_target.test.js，12模板场景及renderer交互 | loading、无role/status历史、弹窗打开后切换为审计；原组件测试失败 | Passed |

补充回归：
- Passed：后端 `python -m pytest test/unit -m 'not slow' -q -o addopts=`：2004 passed，另7 subtests。
- Passed：工程契约检查；检查器单测62项。
- Passed：Linux `pnpm run test:unit`：320 passed，0 failed。
- Passed：变更文件 Ruff/格式/ESLint、Web build、diff检查。
- Inspected：全量 ESLint 在 Windows/Linux 均报告未修改的 `web/test/unit/pdfPreviewAssets.test.js` 两处 Buffer 未定义（24、40行）；文件与基线 9820648e 字节一致，不宣称全部门禁通过。Windows此前PDF路径测试失败，Linux全量未复现。

## 简化 / 删除验收

不涉及。

## 独立语义 Review

独立 Reviewer 审查需求、完整反馈 diff 及测试，发现历史 DTO 缺失 role/status 时误隐藏按钮，已修复并补回归；复审确认闭合。最终交互测试和 decision 复审无新增阻断。Review 不替代测试。

## 未验证范围与风险

- Not run：生产部署、全部集成/E2E、真实模型 provider 和容器沙箱工具执行。
- live 使用 memory provisioner，不代表 Docker 沙箱行为验收。实际执行测试与提交版仅排版差异，AST相同；服务代码字节一致。
- 另有独立 ASGI+PostgreSQL 探针通过，但其认证/评分替身不替代上述完整登录测试。
- 新增422收紧旧行为；既有非法反馈不清理，历史统计不随之净化。

## 事故反馈

未认定为已发生的高影响线上事故；缺陷反证与回归已包含。

## 界面变更

浏览器隔离组件页验证：正常助手显示点赞/点踩/复制；审计及用户只保留复制，模型名保留。截图已本地检查，未上传公开附件；不是生产会话浏览器E2E。真实Vue模板与交互回归包含在PR中。

## 关联事项

无关联Issue。

## 补充说明

无数据库迁移、无新依赖，不自动部署。一个PR只处理反馈目标契约。